### PR TITLE
remove hardcoded config file paths for server, proxy and agent

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -30,6 +30,9 @@
 #   When this is monitored by an proxy, please fill in the name of this proxy.
 #   If the proxy is also installed via this module, please fill in the FQDN
 #
+# [*agent_config*]
+#   Zabbix Agent config path.
+#
 # [*agent_use_ip*]
 #   When true, when creating hosts via the zabbix-api, it will configure that
 #   connection should me made via ip, not fqdn.
@@ -162,6 +165,7 @@ class zabbix::agent (
   $manage_repo          = $zabbix::params::manage_repo,
   $manage_resources     = $zabbix::params::manage_resources,
   $monitored_by_proxy   = $zabbix::params::monitored_by_proxy,
+  $agent_config         = $zabbix::params::agent_config,
   $agent_use_ip         = $zabbix::params::agent_use_ip,
   $zbx_group            = $zabbix::params::agent_zbx_group,
   $zbx_templates        = $zabbix::params::agent_zbx_templates,
@@ -262,7 +266,7 @@ class zabbix::agent (
   }
 
   # Configuring the zabbix-agent configuration file
-  file { '/etc/zabbix/zabbix_agentd.conf':
+  file { $agent_config:
     ensure  => present,
     owner   => 'zabbix',
     group   => 'zabbix',
@@ -280,7 +284,7 @@ class zabbix::agent (
     group   => 'zabbix',
     recurse => true,
     purge   => true,
-    require => File['/etc/zabbix/zabbix_agentd.conf'],
+    require => File[$agent_config],
   }
 
   # Manage firewall

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -47,6 +47,7 @@ class zabbix::params {
   $apache_ssl_chain               = undef
   $server_api_user                = 'Admin'
   $server_api_pass                = 'zabbix'
+  $server_config                  = '/etc/zabbix/zabbix_server.conf' 
   $server_nodeid                  = '0'
   $server_listenport              = '10051'
   $server_sourceip                = undef
@@ -110,6 +111,7 @@ class zabbix::params {
 
   # Agent specific params
   $monitored_by_proxy             = undef
+  $agent_config                   = '/etc/zabbix/zabbix_agentd.conf'
   $agent_use_ip                   = true
   $agent_zbx_group                = 'Linux servers'
   $agent_zbx_templates            = [ 'Template OS Linux', 'Template App SSH Service' ]
@@ -143,6 +145,7 @@ class zabbix::params {
   $agent_loadmodule               = undef
 
   # Proxy specific params
+  $proxy_config                  = '/etc/zabbix/zabbix_proxy.conf'
   $proxy_use_ip                  = true
   $proxy_zbx_templates           = [ 'Template App Zabbix Proxy' ]
   $proxy_mode                    = '0'

--- a/manifests/proxy.pp
+++ b/manifests/proxy.pp
@@ -31,6 +31,9 @@
 #   When true, it will export resources so that the zabbix-server can create
 #   via the zabbix-api proxy.
 #
+# [*proxy_config*]
+#   Zabbix Proxy config path.
+#
 # [*use_ip*]
 #   When true, when creating proxies via the zabbix-api, it will configure that
 #   connection should me made via ip, not fqdn.
@@ -231,6 +234,7 @@ class zabbix::proxy (
   $manage_firewall         = $zabbix::params::manage_firewall,
   $manage_repo             = $zabbix::params::manage_repo,
   $manage_resources        = $zabbix::params::manage_resources,
+  $proxy_config            = $zabbix::params::proxy_config,
   $use_ip                  = $zabbix::params::proxy_use_ip,
   $zbx_templates           = $zabbix::params::proxy_zbx_templates,
   $mode                    = $zabbix::params::proxy_mode,
@@ -391,7 +395,7 @@ class zabbix::proxy (
     require    => [
       Package["zabbix-proxy-${db}"],
       File[$include_dir],
-      File['/etc/zabbix/zabbix_proxy.conf']
+      File[$proxy_config]
     ],
   }
 
@@ -410,7 +414,7 @@ class zabbix::proxy (
   }
 
   # Configuring the zabbix-proxy configuration file
-  file { '/etc/zabbix/zabbix_proxy.conf':
+  file { $proxy_config:
     ensure  => present,
     owner   => 'zabbix',
     group   => 'zabbix',
@@ -424,7 +428,7 @@ class zabbix::proxy (
   # Include dir for specific zabbix-proxy checks.
   file { $include_dir:
     ensure  => directory,
-    require => File['/etc/zabbix/zabbix_proxy.conf'],
+    require => File[$proxy_config],
   }
 
   # Manage firewall

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -71,6 +71,9 @@
 # [*zabbix_api_pass*]
 #   Password of the user which connects to the api. Default: zabbix
 #
+# [*server_config*]
+#   Zabbix Server Config Path
+#
 # [*nodeid*]
 #   Unique nodeid in distributed setup.
 #   (Deprecated since 2.4)
@@ -297,6 +300,7 @@ class zabbix::server (
   $apache_ssl_chain        = $zabbix::params::apache_ssl_chain,
   $zabbix_api_user         = $zabbix::params::server_api_user,
   $zabbix_api_pass         = $zabbix::params::server_api_pass,
+  $server_config           = $zabbix::params::server_config,
   $nodeid                  = $zabbix::params::server_nodeid,
   $listenport              = $zabbix::params::server_listenport,
   $sourceip                = $zabbix::params::server_sourceip,
@@ -500,12 +504,12 @@ class zabbix::server (
     require    => [
       Package["zabbix-server-${db}"],
       File[$include_dir],
-      File['/etc/zabbix/zabbix_server.conf']
+      File[$server_config]
     ],
   }
 
   # Configuring the zabbix-server configuration file
-  file { '/etc/zabbix/zabbix_server.conf':
+  file { '$server_config':
     ensure  => present,
     owner   => 'zabbix',
     group   => 'zabbix',
@@ -532,7 +536,7 @@ class zabbix::server (
     ensure  => directory,
     owner   => 'zabbix',
     group   => 'zabbix',
-    require => File['/etc/zabbix/zabbix_server.conf'],
+    require => File[$server_config],
   }
 
   # Is set to true, it will create the apache vhost.


### PR DESCRIPTION
removed the hardcoded config paths for agent, server and config

the new upstream default is /etc, and the epel rpm does create symliks forom /etc/zabbix/* to /etc, this causes errors. 

btw: sucessfull testet  the module on centos7 (with this changes)