### PR TITLE
setting manage_repo to false breaks server install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ cache: bundler
 rvm:
   - 2.0.0
 
-script: "bundle exec rake rspec"
+script: "bundle exec rake spec"
 
 env:
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: ruby
 cache: bundler
 
 rvm:
-  - 1.8.7
-  - 1.9.3
   - 2.0.0
 
 script: "bundle exec rake rspec"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: ruby
+cache: bundler
+
+rvm:
+  - 1.8.7
+  - 1.9.3
+  - 2.0.0
+
+script: "bundle exec rake rspec"
+
+env:
+  matrix:
+    - PUPPET_GEM_VERSION="~> 2.7.0"
+    - PUPPET_GEM_VERSION="~> 3.7.3"
+
+notifications:
+  email:
+    on_failure: change
+    on_success: never

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ When using this module, you can monitor your whole environment with zabbix. It c
 
 With the 0.4.0 release, you can - when you have configured exported resources - configure agents and proxies in the webinterface. So when you add an zabbix::agent to an host, it first install the agent onto the host. It will send some data to the puppetdb and when puppet runs on the zabbix-server it will create this new host via the zabbix-api.
 
-Be aware when you have a lot of hosts, it will increase the puppet runtime on the zabbix-server host. It will check via the zabbix-api if hosts exits and costs time. 
+Be aware when you have a lot of hosts, it will increase the puppet runtime on the zabbix-server host. It will check via the zabbix-api if hosts exits and costs time.
 
 This module make uses of this gem: https://github.com/express42/zabbixapi
 With this gem it is possible to create/update hosts/proxy in ruby easy.
@@ -89,7 +89,7 @@ This will install an basic zabbix-server instance. You'll have to decide if you 
 
 You can see at "usage" in this documentation how all of this can be achieved.
 
-You will need to supply one parameter: zabbix_url. This is the url on which the zabbix instance will be available. With the example at "setup", the zabbix webinterface will be: http://zabbix.example.com. 
+You will need to supply one parameter: zabbix_url. This is the url on which the zabbix instance will be available. With the example at "setup", the zabbix webinterface will be: http://zabbix.example.com.
 
 When installed succesfully, zabbix web interface will be accessable and you can login with the default credentials:
 
@@ -291,7 +291,7 @@ When installed on seperate machine, the zabbix::server configuration should be u
 ```ruby
 node server01.example.com {
   class { 'zabbix::server':
-    zabbix_url  => 'zabbix.example.com', 
+    zabbix_url  => 'zabbix.example.com',
     javagateway => '192.168.20.15',
   }
 }
@@ -302,7 +302,7 @@ Or when using with an zabbix-proxy:
 ```ruby
 node server11.example.com {
   class { 'zabbix::proxy':
-    zabbix_server_host => '192.168.20.11', 
+    zabbix_server_host => '192.168.20.11',
     javagateway        => '192.168.20.15',
   }
 }
@@ -341,9 +341,28 @@ zabbix::userparameter::data:
 
 ##Reference
 There are some overall parameters which exists on all of the classes:
-* `zabbix_version`: You can specifiy which zabbix release needs to be installed. Default is '2.4'. 
+* `zabbix_version`: You can specify which zabbix release needs to be installed. Default is '2.4'.
+  ```ruby
+  # sepcify the version and pass it to each class that uses the parameter
+  $zabbix_vesion = '2.2'
+
+  class { 'zabbix::repo':
+    zabbix_version => $zabbix_version,
+  }
+
+  class { 'zabbix':
+    zabbix_version => $zabbix_version,
+  }
+  ```
+
 * `manage_firewall`: Wheter you want to manage the firewall. If true (Which is default), iptables will be configured to allow communications to zabbix ports.
 * `manage_repo`:  If zabbix needs to be installed from the zabbix repositories (Default is true). When you have your own repositories, you'll set this to false. But you'll have to make sure that your repositorie is installed on the host.
+  ```ruby
+  class { 'zabbix::repo':
+    manage_repo => false,
+  }
+  ```
+
 
 The following is only availabe for the following classes: zabbix::server, zabbix::proxy & zabbix::agent
 * `manage_resources`: As of release 0.4.0, when this parameter is set to true (Default is false) it make use of exported resources. You'll have an puppetdb configured before you can use this option. Information from the zabbix::agent, zabbix::proxy and zabbix::userparameters are able to export resources, which will be loaded on the zabbix::server.
@@ -361,7 +380,7 @@ This is the class for installing everything on a single host and thus all parame
 * `apache_use_ssl`: Will create an ssl vhost. Also nonssl vhost will be created for redirect nonssl to ssl vhost.
 * `apache_ssl_cert`: The location of the ssl certificate file. You'll need to make sure this file is present on the system, this module will not install this file.
 * `apache_ssl_key`: The location of the ssl key file. You'll need to make sure this file is present on the system, this module will not install this file.
-* `apache_ssl_cipher`: The ssl cipher used. Cipher is used from: https://wiki.mozilla.org/Security/Server_Side_TLS. 
+* `apache_ssl_cipher`: The ssl cipher used. Cipher is used from: https://wiki.mozilla.org/Security/Server_Side_TLS.
 * `apache_ssl_chain`: The ssl_chain file. You'll need to make sure this file is present on the system, this module will not install this file.
 * `zabbix_api_user`: Username of user in Zabbix which is able to create hosts and edit hosts via the zabbix-api. Default: Admin
 * `zabbix_api_pass`: Password for the user in Zabbix for zabbix-api usage. Default: zabbix
@@ -387,7 +406,7 @@ There are some more zabbix specific parameters, please check them by opening the
 * `zabbix_server_host`: The ipaddress or fqdn of the zabbix server.  
 
 The following parameters is only needed when `manage_resources` is set to true:
-* `use_ip`: Default is set to true. 
+* `use_ip`: Default is set to true.
 * `zbx_templates`: List of templates which are needed for the zabbix-proxy. Default: 'Template App Zabbix Proxy'
 * `mode`: Which kind of proxy it is. 0 -> active, 1 -> passive
 
@@ -435,13 +454,13 @@ Zabbix 2.0:
   * Debian 6, 7
   * xenserver 6
 
-This module is supported on both the community as the Enterprise version of Puppet. 
+This module is supported on both the community as the Enterprise version of Puppet.
 
-Zabbix 1.8 isn't supported (yet) with this module. 
+Zabbix 1.8 isn't supported (yet) with this module.
 
 Ubuntu 10.4 is officially supported by zabbix for Zabbix 2.0. I did have some issues with making it work, probably in a future release it is supported with this module as well.
 
-Please be aware, that when manage_resources is enabled, it can increase an puppet run on the zabbix-server a lot when you have a lot of hosts. 
+Please be aware, that when manage_resources is enabled, it can increase an puppet run on the zabbix-server a lot when you have a lot of hosts.
 
 ##Contributors
 The following have contributed to this puppet module:
@@ -465,7 +484,7 @@ Many thanks for this!
 
 
 ###When using exported resources
-*	Please be aware, that when `manage_resources` is enabled, it can increase an puppet run on the zabbix-server a lot when you have a lot of hosts. 
+*	Please be aware, that when `manage_resources` is enabled, it can increase an puppet run on the zabbix-server a lot when you have a lot of hosts.
 *	First run of puppet on the zabbix-server can result in this error:
 
 ```ruby
@@ -475,7 +494,7 @@ Error: Could not run: can't convert Puppet::Util::Log into Integer
 
 See: http://comments.gmane.org/gmane.comp.sysutils.puppet.user/47508, comment:  Jeff McCune | 20 Nov 20:42 2012
 
-```quote 
+```quote
 This specific issue is a chicken and egg problem where by a provider needs a gem, but the catalog run itself is the thing that provides the gem dependency. That is to say, even in Puppet 3.0 where we delay loading all of the providers until after pluginsync finishes, the catalog run hasn't yet installed the gem when the provider is loaded.
 
 The reason I think this is basically a very specific incarnation of #6907 is because that ticket is pretty specific from a product functionality perspective, "You should not have to run puppet twice to use a provider."
@@ -483,7 +502,7 @@ The reason I think this is basically a very specific incarnation of #6907 is bec
 
 After another puppet run, it will run succesfully.
 
-* On a Red Hat family server, the 2nd run will sometimes go into error: 
+* On a Red Hat family server, the 2nd run will sometimes go into error:
 
 ```ruby
 Could not evaluate: Connection refused - connect(2)

--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,8 @@ require 'puppetlabs_spec_helper/rake_tasks'
 
 desc "Run all RSpec code examples"
 RSpec::Core::RakeTask.new(:rspec) do |t|
-  t.rspec_opts = File.read("spec/spec.opts").chomp || ""
+  #t.rspec_opts = File.read("spec/spec.opts").chomp || ""
+  t.rspec_opts = ['--color', '--format', 'documentation']
 end
 
 SPEC_SUITES = (Dir.entries('spec') - ['.', '..','fixtures']).select {|e| File.directory? "spec/#{e}" }
@@ -14,7 +15,8 @@ namespace :rspec do
     desc "Run #{suite} RSpec code examples"
     RSpec::Core::RakeTask.new(suite) do |t|
       t.pattern = "spec/#{suite}/**/*_spec.rb"
-      t.rspec_opts = File.read("spec/spec.opts").chomp || ""
+      #t.rspec_opts = File.read("spec/spec.opts").chomp || ""
+      t.rspec_opts = ['--color', '--format', 'documentation']
     end
   end
 end

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -248,11 +248,7 @@ class zabbix::agent (
 
   # Check if manage_repo is true.
   if $manage_repo {
-    if ! defined(Class['zabbix::repo']) {
-      class { 'zabbix::repo':
-        zabbix_version => $zabbix_version,
-      }
-    }
+    include zabbix::repo
     Package['zabbix-agent'] {require => Class['zabbix::repo']}
   }
 

--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -15,9 +15,6 @@
 #   The type of zabbix which is used: server or proxy.
 #   This will determine what sql files will be loaded into database.
 #
-# [*zabbix_version*]
-#   This is the zabbix version. Default: 2.4
-#
 # [*zabbix_web*]
 #   This is the hostname of the server which is running the
 #   zabbix-web package. This parameter is used when database_type =
@@ -108,7 +105,6 @@
 #
 class zabbix::database(
   $zabbix_type          = 'server',
-  $zabbix_version       = $zabbix::params::zabbix_version,
   $zabbix_web           = $zabbix::params::zabbix_web,
   $zabbix_web_ip        = $zabbix::params::zabbix_web_ip,
   $zabbix_server        = $zabbix::params::zabbix_server,

--- a/manifests/database/mysql.pp
+++ b/manifests/database/mysql.pp
@@ -17,7 +17,7 @@
 #
 class zabbix::database::mysql (
   $zabbix_type          = '',
-  $zabbix_version       = '',
+  $zabbix_version       = $zabbix::params::zabbix_version,
   $database_schema_path = '',
   $database_name        = '',
   $database_user        = '',

--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -17,7 +17,7 @@
 #
 class zabbix::database::postgresql (
   $zabbix_type          = '',
-  $zabbix_version       = '',
+  $zabbix_version       = $zabbix::params::zabbix_version,
   $database_schema_path = '',
   $database_name        = '',
   $database_user        = '',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -71,6 +71,7 @@
 # Copyright 2014 Werner Dijkerman
 #
 class zabbix (
+
   $zabbix_url              = '',
   $zabbix_version          = $zabbix::params::zabbix_version,
   $zabbix_timezone         = $zabbix::params::zabbix_timezone,
@@ -161,7 +162,6 @@ class zabbix (
     zabbix_version    => $zabbix_version,
     zabbix_timezone   => $zabbix_timezone,
     manage_vhost      => $manage_vhost,
-    manage_repo       => $manage_repo,
     manage_resources  => $manage_resources,
     apache_use_ssl    => $apache_use_ssl,
     apache_ssl_cert   => $apache_ssl_cert,
@@ -186,7 +186,6 @@ class zabbix (
     database_type           => $database_type,
     zabbix_version          => $zabbix_version,
     manage_firewall         => $manage_firewall,
-    manage_repo             => $manage_repo,
     nodeid                  => $nodeid,
     listenport              => $listenport,
     sourceip                => $sourceip,
@@ -254,7 +253,6 @@ class zabbix (
 
   class { 'zabbix::database':
     zabbix_type       => 'server',
-    zabbix_version    => $zabbix_version,
     zabbix_web        => $zabbix_web,
     zabbix_server     => $zabbix_server,
     zabbix_web_ip     => $zabbix_web_ip,
@@ -265,5 +263,10 @@ class zabbix (
     database_user     => $database_user,
     database_password => $database_password,
     database_host     => $database_host,
+    require           => Class['zabbix::repo'],
   }
+
+  # includeing here as the class must, at a minimum, be defined.
+  include zabbix::repo
+
 }

--- a/manifests/javagateway.pp
+++ b/manifests/javagateway.pp
@@ -64,11 +64,7 @@ class zabbix::javagateway(
 
   # Check if manage_repo is true.
   if $manage_repo {
-    if ! defined(Class['zabbix::repo']) {
-      class { 'zabbix::repo':
-        zabbix_version => $zabbix_version,
-      }
-    }
+    include zabbix::repo
     Package['zabbix-java-gateway'] {require => Class['zabbix::repo']}
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -69,10 +69,10 @@ class zabbix::params {
   $server_debuglevel              = '3'
   $server_pidfile                 = '/var/run/zabbix/zabbix_server.pid'
   $server_database_host           = 'localhost'
-  $server_database_name           = 'zabbix-server'
+  $server_database_name           = 'zabbix_server'
   $server_database_schema         = undef
-  $server_database_user           = 'zabbix-server'
-  $server_database_password       = 'zabbix-server'
+  $server_database_user           = 'zabbix_server'
+  $server_database_password       = 'zabbix_server'
   $server_database_socket         = undef
   $server_database_port           = undef
   $server_startpollers            = '5'

--- a/manifests/proxy.pp
+++ b/manifests/proxy.pp
@@ -439,11 +439,7 @@ class zabbix::proxy (
 
   # Check if manage_repo is true.
   if $manage_repo {
-    if ! defined(Class['zabbix::repo']) {
-      class { 'zabbix::repo':
-        zabbix_version => $zabbix_version,
-      }
-    }
+    include zabbix::repo
     Package["zabbix-proxy-${db}"] {require => Class['zabbix::repo']}
   }
 

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -1,10 +1,19 @@
 # == Class: zabbix::repo
 #
-#  This will install the yum repository used for installing zabbix
+#  If enabled, this will install the repository used for installing zabbix
 #
 #  Please note:
 #  This class will be called from zabbix::server, zabbix::proxy and
 #  zabbix::agent. No need for calling this class manually.
+#
+# === Parameters
+#
+# [*manage_repo*]
+#   When true, it will create repository for installing the server.
+#
+# [*zabbix_version*]
+#   This is the zabbix version.
+#
 #
 # === Authors
 #
@@ -15,121 +24,124 @@
 # Copyright 2014 Werner Dijkerman
 #
 class zabbix::repo(
-  $zabbix_version = undef
+  $manage_repo    = $zabbix::params::manage_repo,
+  $zabbix_version = $zabbix::params::zabbix_version,
 ) {
 
-  # Figuring out which major release we have. Or which release name
-  # for debian/ununtu releases.
-  case $::operatingsystemrelease {
-    /^14.04/: {
-      $majorrelease = '14'
-      $ubuntu       = 'trusty'
-    }
-    /^12.04/: {
-      $majorrelease = '12'
-      $ubuntu       = 'precise'
-    }
-    /^10.04/: {
-      $majorrelease = '10'
-      $ubuntu       = 'lucid'
-    }
-    /^7.*/: {
-      $majorrelease = '7'
-      $debian       = 'wheezy'
-    }
-    /^6.*/: {
-      $majorrelease = '6'
-      $debian       = 'squeeze'
-    }
-    /^5.*/: {
-      $majorrelease = '5'
-      $debian       = 'lenny'
-    }
-    # Debian unstable releases look something like "jessie/sid"
-    # In this case, just use the first bit as the version
-    /\/sid$/: {
-      # Zabbix repo doesn't yet support jessie, use wheezy instead
-      if ($::operatingsystemrelease == 'jessie/sid') {
-        $debian = 'wheezy'
-      } else {
-        $debian = regsubst($::operatingsystemrelease, '/sid$', '')
+  if ($manage_repo) {
+    # Figuring out which major release we have. Or which release name
+    # for debian/ununtu releases.
+    case $::operatingsystemrelease {
+      /^14.04/: {
+        $majorrelease = '14'
+        $ubuntu       = 'trusty'
       }
-    }
-    default: {
-      fail("This is an unsupported operating system (${::operatingsystem} ${::operatingsystemrelease})")
-    }
-  }
-
-  case $::operatingsystem {
-    'centos','scientific','redhat','oraclelinux' : {
-      yumrepo { 'zabbix':
-        name     => "Zabbix_${majorrelease}_${::architecture}",
-        descr    => "Zabbix_${majorrelease}_${::architecture}",
-        baseurl  => "http://repo.zabbix.com/zabbix/${zabbix_version}/rhel/${majorrelease}/${::architecture}/",
-        gpgcheck => '1',
-        gpgkey   => 'http://repo.zabbix.com/RPM-GPG-KEY-ZABBIX',
-        priority => '1',
+      /^12.04/: {
+        $majorrelease = '12'
+        $ubuntu       = 'precise'
       }
-      yumrepo { 'zabbix-nonsupported':
-        name     => "Zabbix_nonsupported_${majorrelease}_${::architecture}",
-        descr    => "Zabbix_nonsupported_${majorrelease}_${::architecture}",
-        baseurl  => "http://repo.zabbix.com/non-supported/rhel/${majorrelease}/${::architecture}/",
-        gpgcheck => '1',
-        gpgkey   => 'http://repo.zabbix.com/RPM-GPG-KEY-ZABBIX',
-        priority => '1',
+      /^10.04/: {
+        $majorrelease = '10'
+        $ubuntu       = 'lucid'
       }
-
-    } # END 'centos','redhat','oraclelinux'
-    'XenServer' : {
-      yumrepo { 'zabbix':
-        name     => "Zabbix_${majorrelease}_${::architecture}",
-        descr    => "Zabbix_${majorrelease}_${::architecture}",
-        baseurl  => "http://repo.zabbix.com/zabbix/${zabbix_version}/rhel/5/${::architecture}/",
-        gpgcheck => '1',
-        gpgkey   => 'http://repo.zabbix.com/RPM-GPG-KEY-ZABBIX',
-        priority => '1',
+      /^7.*/: {
+        $majorrelease = '7'
+        $debian       = 'wheezy'
       }
-      yumrepo { 'zabbix-nonsupported':
-        name     => "Zabbix_nonsupported_${majorrelease}_${::architecture}",
-        descr    => "Zabbix_nonsupported_${majorrelease}_${::architecture}",
-        baseurl  => "http://repo.zabbix.com/non-supported/rhel/5/${::architecture}/",
-        gpgcheck => '1',
-        gpgkey   => 'http://repo.zabbix.com/RPM-GPG-KEY-ZABBIX',
-        priority => '1',
+      /^6.*/: {
+        $majorrelease = '6'
+        $debian       = 'squeeze'
       }
-
-    } # END 'XenServer'
-    'debian' : {
-      if ($::architecture == 'armv6l') {
-        apt::source { 'zabbix':
-          location    => 'http://naizvoru.com/raspbian/zabbix',
-          release     => $debian,
-          repos       => 'main',
-          key         => 'D54A213C80E871A7',
-          key_source  => 'http://naizvoru.com/raspbian/zabbix/conf/boris@steki.net.gpg.key',
-          include_src => false,
+      /^5.*/: {
+        $majorrelease = '5'
+        $debian       = 'lenny'
+      }
+      # Debian unstable releases look something like "jessie/sid"
+      # In this case, just use the first bit as the version
+      /\/sid$/: {
+        # Zabbix repo doesn't yet support jessie, use wheezy instead
+        if ($::operatingsystemrelease == 'jessie/sid') {
+          $debian = 'wheezy'
+        } else {
+          $debian = regsubst($::operatingsystemrelease, '/sid$', '')
         }
-      } else {
+      }
+      default: {
+        fail("This is an unsupported operating system (${::operatingsystem} ${::operatingsystemrelease})")
+      }
+    }
+
+    case $::operatingsystem {
+      'centos','scientific','redhat','oraclelinux' : {
+        yumrepo { 'zabbix':
+          name     => "Zabbix_${majorrelease}_${::architecture}",
+          descr    => "Zabbix_${majorrelease}_${::architecture}",
+          baseurl  => "http://repo.zabbix.com/zabbix/${zabbix_version}/rhel/${majorrelease}/${::architecture}/",
+          gpgcheck => '1',
+          gpgkey   => 'http://repo.zabbix.com/RPM-GPG-KEY-ZABBIX',
+          priority => '1',
+        }
+        yumrepo { 'zabbix-nonsupported':
+          name     => "Zabbix_nonsupported_${majorrelease}_${::architecture}",
+          descr    => "Zabbix_nonsupported_${majorrelease}_${::architecture}",
+          baseurl  => "http://repo.zabbix.com/non-supported/rhel/${majorrelease}/${::architecture}/",
+          gpgcheck => '1',
+          gpgkey   => 'http://repo.zabbix.com/RPM-GPG-KEY-ZABBIX',
+          priority => '1',
+        }
+
+      } # END 'centos','redhat','oraclelinux'
+      'XenServer' : {
+        yumrepo { 'zabbix':
+          name     => "Zabbix_${majorrelease}_${::architecture}",
+          descr    => "Zabbix_${majorrelease}_${::architecture}",
+          baseurl  => "http://repo.zabbix.com/zabbix/${zabbix_version}/rhel/5/${::architecture}/",
+          gpgcheck => '1',
+          gpgkey   => 'http://repo.zabbix.com/RPM-GPG-KEY-ZABBIX',
+          priority => '1',
+        }
+        yumrepo { 'zabbix-nonsupported':
+          name     => "Zabbix_nonsupported_${majorrelease}_${::architecture}",
+          descr    => "Zabbix_nonsupported_${majorrelease}_${::architecture}",
+          baseurl  => "http://repo.zabbix.com/non-supported/rhel/5/${::architecture}/",
+          gpgcheck => '1',
+          gpgkey   => 'http://repo.zabbix.com/RPM-GPG-KEY-ZABBIX',
+          priority => '1',
+        }
+
+      } # END 'XenServer'
+      'debian' : {
+        if ($::architecture == 'armv6l') {
+          apt::source { 'zabbix':
+            location    => 'http://naizvoru.com/raspbian/zabbix',
+            release     => $debian,
+            repos       => 'main',
+            key         => 'D54A213C80E871A7',
+            key_source  => 'http://naizvoru.com/raspbian/zabbix/conf/boris@steki.net.gpg.key',
+            include_src => false,
+          }
+        } else {
+          apt::source { 'zabbix':
+            location   => "http://repo.zabbix.com/zabbix/${zabbix_version}/debian/",
+            release    => $debian,
+            repos      => 'main',
+            key        => '79EA5ED4',
+            key_source => 'http://repo.zabbix.com/zabbix-official-repo.key',
+          }
+        }
+      } # END 'debian'
+      'ubuntu' : {
         apt::source { 'zabbix':
-          location   => "http://repo.zabbix.com/zabbix/${zabbix_version}/debian/",
-          release    => $debian,
+          location   => "http://repo.zabbix.com/zabbix/${zabbix_version}/ubuntu/",
+          release    => $ubuntu,
           repos      => 'main',
           key        => '79EA5ED4',
           key_source => 'http://repo.zabbix.com/zabbix-official-repo.key',
         }
+      } # END 'ubuntu'
+      default : {
+        fail('Unrecognized operating system for webserver')
       }
-    } # END 'debian'
-    'ubuntu' : {
-      apt::source { 'zabbix':
-        location   => "http://repo.zabbix.com/zabbix/${zabbix_version}/ubuntu/",
-        release    => $ubuntu,
-        repos      => 'main',
-        key        => '79EA5ED4',
-        key_source => 'http://repo.zabbix.com/zabbix-official-repo.key',
-      }
-    } # END 'ubuntu'
-    default : {
-      fail('Unrecognized operating system for webserver')
     }
-  }
+  } # end if ($manage_repo)
 }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -388,7 +388,7 @@ class zabbix::server (
     require    => [
       Package["zabbix-server-${db}"],
       File[$include_dir],
-      File[$server_configfile_path]
+      File[$server_configfile_path],
       Class["zabbix::database::${database_type}"]
     ],
   }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -389,6 +389,7 @@ class zabbix::server (
       Package["zabbix-server-${db}"],
       File[$include_dir],
       File[$server_configfile_path]
+      Class["zabbix::database::${database_type}"]
     ],
   }
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -23,9 +23,6 @@
 # [*manage_firewall*]
 #   When true, it will create iptables rules.
 #
-# [*manage_repo*]
-#   When true, it will create repository for installing the server.
-#
 # [*server_configfile_path*]
 #   Server config file path defaults to /etc/zabbix/zabbix_server.conf
 #
@@ -259,7 +256,6 @@ class zabbix::server (
   $zabbix_version          = $zabbix::params::zabbix_version,
   $zabbix_package_state    = $zabbix::params::zabbix_package_state,
   $manage_firewall         = $zabbix::params::manage_firewall,
-  $manage_repo             = $zabbix::params::manage_repo,
   $server_configfile_path  = $zabbix::params::server_configfile_path,
   $server_config_owner     = $zabbix::params::server_config_owner,
   $server_config_group     = $zabbix::params::server_config_group,
@@ -329,9 +325,10 @@ class zabbix::server (
   $loadmodule              = $zabbix::params::server_loadmodule,
   ) inherits zabbix::params {
 
+  include zabbix::repo
+  
   # Check some if they are boolean
   validate_bool($manage_firewall)
-  validate_bool($manage_repo)
 
   # Get the correct database_type. We need this for installing the
   # correct package and loading the sql files.
@@ -368,15 +365,6 @@ class zabbix::server (
     }
     default: {
       fail('unrecognized database type for server.')
-    }
-  }
-
-  # Check if manage_repo is true.
-  if $manage_repo {
-    if ! defined(Class['zabbix::repo']) {
-      class { 'zabbix::repo':
-        zabbix_version => $zabbix_version,
-      }
     }
   }
 

--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -35,9 +35,6 @@
 #   When true, it will create an vhost for apache. The parameter zabbix_url
 #   has to be set.
 #
-# [*manage_repo*]
-#   When true, it will create repository for installing the server.
-#
 # [*manage_resouces*]
 #   When true, it will export resources to something like puppetdb.
 #   When set to true, you'll need to configure 'storeconfigs' to make
@@ -131,7 +128,6 @@ class zabbix::web (
   $zabbix_timezone         = $zabbix::params::zabbix_timezone,
   $zabbix_package_state    = $zabbix::params::zabbix_package_state,
   $manage_vhost            = $zabbix::params::manage_vhost,
-  $manage_repo             = $zabbix::params::manage_repo,
   $manage_resources        = $zabbix::params::manage_resources,
   $apache_use_ssl          = $zabbix::params::apache_use_ssl,
   $apache_ssl_cert         = $zabbix::params::apache_ssl_cert,
@@ -150,6 +146,8 @@ class zabbix::web (
   $zabbix_server           = $zabbix::params::zabbix_server,
   $zabbix_listenport       = $zabbix::params::server_listenport,
 ) inherits zabbix::params {
+
+  include zabbix::repo
 
   # use the correct db.
   case $database_type {
@@ -186,15 +184,6 @@ class zabbix::web (
       apache_use_ssl => $apache_use_ssl,
     }
   }
-
-  # Check if manage_repo is true.
-  if $manage_repo {
-    if ! defined(Class['zabbix::repo']) {
-      class { 'zabbix::repo':
-        zabbix_version => $zabbix_version,
-      }
-    }
-  } # END if $manage_repo
 
   case $::operatingsystem {
     'ubuntu', 'debian' : {


### PR DESCRIPTION
You have this chunk of code in `zabbix::web`

```puppet
# Check if manage_repo is true.
  if $manage_repo {
    if ! defined(Class['zabbix::repo']) {
      class { 'zabbix::repo':
        zabbix_version => $zabbix_version,
      }
    }
  } # END if $manage_repo
```
but nothing that ensures it runs before the this chunk in the same file:

```puppet
default : {
      package { "zabbix-web-${db}":
        ensure  => $zabbix_package_state,
        before  => [
          File['/etc/zabbix/web/zabbix.conf.php'],
          Package['zabbix-web']
        ],
        require => Class['zabbix::repo'],
      }
```

This causes the following error: `Could not retrieve catalog from remote server: Error 400 on SERVER: Invalid relationship: Package[zabbix-web-mysql] { require => Class[Zabbix::Repo] }, because Class[Zabbix::Repo] doesn't seem to be in the catalog`

I see how to fix this and will be submitting a pull request shortly but wanted to go ahead and list it as a bug in case anyone else is effected by this.