### PR TITLE
Fix name of agent config file in params.pp

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -123,7 +123,7 @@ class zabbix::params {
   $server_loadmodule              = undef
 
   # Agent specific params
-  $agent_configfile_path          = '/etc/zabbix/zabbix_agent.conf'
+  $agent_configfile_path          = '/etc/zabbix/zabbix_agentd.conf'
   $monitored_by_proxy             = undef
   $agent_use_ip                   = true
   $agent_zbx_group                = 'Linux servers'


### PR DESCRIPTION
The default config path in params.pp was missing a “d” after “agent”.