### PR TITLE
This resolves dj-wasabi/puppet-zabbix#37.

### DIFF
--- a/lib/puppet/provider/zabbix_host/ruby.rb
+++ b/lib/puppet/provider/zabbix_host/ruby.rb
@@ -41,6 +41,11 @@ Puppet::Type.type(:zabbix_host).provide(:ruby, :parent => Puppet::Provider::Zabb
     else
         use_ip = 0
     end
+
+    # When using DNS you still have to send a value for ip
+    if ipaddress.nil? and use_ip == 0
+      ipaddress = ''
+    end
  
     # Now we create the host
     hostid = zbx.hosts.create_or_update(


### PR DESCRIPTION
API docs say that ip must not be null.
https://www.zabbix.com/documentation/2.4/manual/api/reference/hostinterface/object#host_interface