### PR TITLE
Correctly rewrite the root when using SSL, fixes #47

### DIFF
--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -241,7 +241,7 @@ class zabbix::web (
           {
             comment      => 'redirect all to https',
             rewrite_cond => ['%{SERVER_PORT} !^443$'],
-            rewrite_rule => ["^/(.+)$ https://${zabbix_url}/\$1 [L,R]"],
+            rewrite_rule => ["^/(.*)$ https://${zabbix_url}/\$1 [L,R]"],
           }
         ],
       }


### PR DESCRIPTION
This works for me more correctly, otherwise accessing the / keeps you on http:// and when POST'ing you get a weird 2nd login screen.