### PR TITLE
Fix agent listenip

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -213,7 +213,7 @@ class zabbix::agent (
   # to network name. If more than 1 interfaces are available, we
   # can find the ipaddress of this specific interface if listenip
   # is set to for example "eth1" or "bond0.73".
-  if $listenip == undefined {
+  if ($listenip == defined) {
     if ($listenip =~ /^(eth|bond|lxc).*/) {
       $int_name = "ipaddress_${listenip}"
       $listen_ip = inline_template('<%= scope.lookupvar(int_name) %>')


### PR DESCRIPTION
Fix agent listenip construct to be the same as in proxy.pp. This fixes a bug (== vs != or defined vs undefined) and style.