### PR TITLE
Fix in params.pp with default parameter of zabbix proxy for ubuntu

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -174,7 +174,7 @@ class zabbix::params {
   $proxy_debuglevel              = '3'
   $proxy_pidfile                 = '/var/run/zabbix/proxy_server.pid'
   $proxy_database_host           = 'localhost'
-  $proxy_database_name           = 'zabbix-proxy'
+  $proxy_database_name           = 'zabbix_proxy'
   $proxy_database_schema         = undef
   $proxy_database_user           = 'zabbix-proxy'
   $proxy_database_password       = 'zabbix-proxy'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -169,10 +169,10 @@ class zabbix::params {
   $proxy_zabbix_server_port      = '10051'
   $proxy_listenport              = '10051'
   $proxy_sourceip                = undef
-  $proxy_logfile                 = '/var/log/zabbix/proxy_server.log'
+  $proxy_logfile                 = '/var/log/zabbix/zabbix_proxy.log'
   $proxy_logfilesize             = '10'
   $proxy_debuglevel              = '3'
-  $proxy_pidfile                 = '/var/run/zabbix/proxy_server.pid'
+  $proxy_pidfile                 = '/var/run/zabbix/zabbix_proxy.pid'
   $proxy_database_host           = 'localhost'
   $proxy_database_name           = 'zabbix_proxy'
   $proxy_database_schema         = undef


### PR DESCRIPTION
Some mistakes in params.pp for zabbix proxy (mysql)