### PR TITLE
Fix manage_repo parameter on the zabbix class

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -267,7 +267,9 @@ class zabbix (
     require           => Class['zabbix::repo'],
   }
 
-  # includeing here as the class must, at a minimum, be defined.
-  include zabbix::repo
+  class {
+    'zabbix::repo':
+      manage_repo => $manage_repo,
+  }
 
 }


### PR DESCRIPTION
Without this commit, the manage_repo in the main class is not doing
anything.

This commit fixes that by explicitely passing the parameter to the
zabbix::repo class.

See also GH-64 for a different way of solving this