### PR TITLE
bugfix for vhosts in apache 2.4

### DIFF
--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -268,7 +268,7 @@ class zabbix::web (
         merge({ path => '/usr/share/zabbix/api', provider => 'directory', }, $directory_deny),
         merge({ path => '/usr/share/zabbix/include', provider => 'directory', }, $directory_deny),
         merge({ path => '/usr/share/zabbix/include/classes', provider => 'directory', }, $directory_deny),
-      ,
+      ],
       custom_fragment => "
    php_value max_execution_time 300
    php_value memory_limit 128M


### PR DESCRIPTION
Currently it's not possible to manage vhosts in Apache 2.4. The module is using deprecated functions that only work for 2.2. This commit solves that and keeps it backwards compatible.