### PR TITLE
Multi-node setup: Web class wasn't properly configuring database ports

### DIFF
--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -262,14 +262,14 @@ class zabbix::web (
     }
 
     apache::vhost { $zabbix_url:
-      docroot         => '/usr/share/zabbix',
-      port            => $apache_listen_port,
-      directories     => [
-        merge({ path            => '/usr/share/zabbix', provider        => 'directory', }, $directory_allow),
-        merge({ path            => '/usr/share/zabbix/conf', provider        => 'directory', }, $directory_deny),
-        merge({ path            => '/usr/share/zabbix/api', provider        => 'directory', }, $directory_deny),
-        merge({ path            => '/usr/share/zabbix/include', provider        => 'directory', }, $directory_deny),
-        merge({ path            => '/usr/share/zabbix/include/classes', provider        => 'directory', }, $directory_deny),
+      docroot        => '/usr/share/zabbix',
+      port           => $apache_listen_port,
+      directories    => [
+        merge({ path => '/usr/share/zabbix', provider => 'directory', }, $directory_allow),
+        merge({ path => '/usr/share/zabbix/conf', provider => 'directory', }, $directory_deny),
+        merge({ path => '/usr/share/zabbix/api', provider => 'directory', }, $directory_deny),
+        merge({ path => '/usr/share/zabbix/include', provider => 'directory', }, $directory_deny),
+        merge({ path => '/usr/share/zabbix/include/classes', provider => 'directory', }, $directory_deny),
       ],
       custom_fragment => "
    php_value max_execution_time 300

--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -153,9 +153,11 @@ class zabbix::web (
   case $database_type {
     'postgresql': {
       $db = 'pgsql'
+      $database_port = '5432'
     }
     'mysql': {
       $db = 'mysql'
+      $database_port = '3306'
     }
     default: {
       fail('unrecognized database type for server.')
@@ -260,14 +262,19 @@ class zabbix::web (
     }
 
     apache::vhost { $zabbix_url:
-      docroot     => '/usr/share/zabbix',
-      port        => $apache_listen_port,
-      directories => [
-        merge({ path => '/usr/share/zabbix', provider => 'directory', }, $directory_allow),
-        merge({ path => '/usr/share/zabbix/conf', provider => 'directory', }, $directory_deny),
-        merge({ path => '/usr/share/zabbix/api', provider => 'directory', }, $directory_deny),
-        merge({ path => '/usr/share/zabbix/include', provider => 'directory', }, $directory_deny),
-        merge({ path => '/usr/share/zabbix/include/classes', provider => 'directory', }, $directory_deny),
+      docroot         => '/usr/share/zabbix',
+      port            => $apache_listen_port,
+      directories     => [
+        merge({ path            => '/usr/share/zabbix',
+ provider        => 'directory', }, $directory_allow),
+        merge({ path            => '/usr/share/zabbix/conf',
+ provider        => 'directory', }, $directory_deny),
+        merge({ path            => '/usr/share/zabbix/api',
+ provider        => 'directory', }, $directory_deny),
+        merge({ path            => '/usr/share/zabbix/include',
+ provider        => 'directory', }, $directory_deny),
+        merge({ path            => '/usr/share/zabbix/include/classes',
+ provider        => 'directory', }, $directory_deny),
       ],
       custom_fragment => "
    php_value max_execution_time 300

--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -265,16 +265,11 @@ class zabbix::web (
       docroot         => '/usr/share/zabbix',
       port            => $apache_listen_port,
       directories     => [
-        merge({ path            => '/usr/share/zabbix',
- provider        => 'directory', }, $directory_allow),
-        merge({ path            => '/usr/share/zabbix/conf',
- provider        => 'directory', }, $directory_deny),
-        merge({ path            => '/usr/share/zabbix/api',
- provider        => 'directory', }, $directory_deny),
-        merge({ path            => '/usr/share/zabbix/include',
- provider        => 'directory', }, $directory_deny),
-        merge({ path            => '/usr/share/zabbix/include/classes',
- provider        => 'directory', }, $directory_deny),
+        merge({ path            => '/usr/share/zabbix', provider        => 'directory', }, $directory_allow),
+        merge({ path            => '/usr/share/zabbix/conf', provider        => 'directory', }, $directory_deny),
+        merge({ path            => '/usr/share/zabbix/api', provider        => 'directory', }, $directory_deny),
+        merge({ path            => '/usr/share/zabbix/include', provider        => 'directory', }, $directory_deny),
+        merge({ path            => '/usr/share/zabbix/include/classes', provider        => 'directory', }, $directory_deny),
       ],
       custom_fragment => "
    php_value max_execution_time 300


### PR DESCRIPTION
"database_port" is not properly set when web node is split from master node. 

Puppet code:

```

# Zabbix Web Node

node 'MASTER' {
  file { '/etc/yum.conf':
    source => 'puppet:///modules/yum/yum.conf',
    owner  => root,
    group  => root,
  }
  class { 'apache':
      mpm_module => 'prefork',
  }
  class { 'apache::mod::php': }
  class { 'zabbix::web':
    zabbix_url      => '',
    zabbix_server   => 'MASTER',
    database_host   => 'MASTER',
    zabbix_api_user => 'whatever',
    zabbix_api_pass => 'crazysecurepassword',
    database_type   => 'mysql',
  }
}
```


Output:
```
/etc/zabbix/web/zabbix.conf.php

<?php
// Zabbix GUI configuration file
global $DB;

$DB['TYPE']     = 'MYSQL';
$DB['SERVER']   = 'c2t06545.itcs.hp.com';
$DB['PORT']     = '0';
$DB['DATABASE'] = 'zabbix_server';
$DB['USER']     = 'zabbix_server';
$DB['PASSWORD'] = 'zabbix_server';

// SCHEMA is relevant only for IBM_DB2 database
$DB['SCHEMA'] = '';

$ZBX_SERVER      = 'c2t06545.itcs.hp.com';
$ZBX_SERVER_PORT = '10051';
$ZBX_SERVER_NAME = 'c2t06545.itcs.hp.com';

$IMAGE_FORMAT_DEFAULT = IMAGE_FORMAT_PNG;
?>
```

