### PR TITLE
Allow to not purge include dir. 

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -198,6 +198,7 @@ class zabbix::agent (
   $zabbix_alias          = $zabbix::params::agent_zabbix_alias,
   $timeout               = $zabbix::params::agent_timeout,
   $include_dir           = $zabbix::params::agent_include,
+  $include_dir_purge     = $zabbix::params::agent_include_purge,
   $unsafeuserparameters  = $zabbix::params::agent_unsafeuserparameters,
   $userparameter         = $zabbix::params::agent_userparameter,
   $loadmodulepath        = $zabbix::params::agent_loadmodulepath,
@@ -286,7 +287,7 @@ class zabbix::agent (
     owner   => 'zabbix',
     group   => 'zabbix',
     recurse => true,
-    purge   => true,
+    purge   => $include_dir_purge,
     notify  => Service['zabbix-agent'],
     require => File[$agent_configfile_path],
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -153,6 +153,7 @@ class zabbix::params {
   $agent_zabbix_alias             = undef
   $agent_timeout                  = '3'
   $agent_include                  = '/etc/zabbix/zabbix_agentd.d'
+  $agent_include_purge            = true,
   $agent_unsafeuserparameters     = '0'
   $agent_userparameter            = undef
   $agent_loadmodulepath           = '/usr/lib/modules'


### PR DESCRIPTION
For example if userparameter configs is managed via VCS repo. Default value is set to "true", as was in original implementation.