### PR TITLE
Unneeded coma in parameters

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -153,7 +153,7 @@ class zabbix::params {
   $agent_zabbix_alias             = undef
   $agent_timeout                  = '3'
   $agent_include                  = '/etc/zabbix/zabbix_agentd.d'
-  $agent_include_purge            = true,
+  $agent_include_purge            = true
   $agent_unsafeuserparameters     = '0'
   $agent_userparameter            = undef
   $agent_loadmodulepath           = '/usr/lib/modules'


### PR DESCRIPTION
Found mistake in params.pp