### PR TITLE
Fixed apt repo error

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -135,7 +135,7 @@ class zabbix::repo(
           location   => "http://repo.zabbix.com/zabbix/${zabbix_version}/ubuntu/",
           release    => $ubuntu,
           repos      => 'main',
-          key        => 'FBABD5FB20255ECAB22EE194D13D58E479EA5ED4',
+          key        => '79EA5ED4',
           key_source => 'http://repo.zabbix.com/zabbix-official-repo.key',
         }
       } # END 'ubuntu'


### PR DESCRIPTION
Corrected the repo key for ubuntu.

In ubuntu trusty, it was giving below error, changing the repo key to correct value
fixed the error.
```
Apr 23 22:50:28 node1 puppet-user[14480]: validate_re():
"FBABD5FB20255ECAB22EE194D13D58E479EA5ED4" does not match
["\\A(0x)?[0-9a-fA-F]{8}\\Z", "\\A(0x)?[0-9a-fA-F]{16}\\Z"] at
/etc/puppet/environments/production/modules/apt/manifests/key.pp:60 on node
node1.domain.name
```