### PR TITLE
import templates and create hostgroup if missing

### DIFF
--- a/lib/puppet/provider/zabbix_host/ruby.rb
+++ b/lib/puppet/provider/zabbix_host/ruby.rb
@@ -14,6 +14,7 @@ Puppet::Type.type(:zabbix_host).provide(:ruby, :parent => Puppet::Provider::Zabb
     use_ip = @resource[:use_ip]
     port = @resource[:port]
     hostgroup = @resource[:group]
+    hostgroup_create = @resource[:group_create]
     templates = @resource[:templates]
     proxy = @resource[:proxy]
     zabbix_url = @resource[:zabbix_url]
@@ -46,10 +47,19 @@ Puppet::Type.type(:zabbix_host).provide(:ruby, :parent => Puppet::Provider::Zabb
     if ipaddress.nil? and use_ip == 0
       ipaddress = ''
     end
+
+    if hostgroup_create == true
+        hostgroup_create = 1
+    else
+        hostgroup_create = 0
+    end
  
     # First check if we have an correct hostgroup and if not, we raise an error.
     search_hostgroup = zbx.hostgroups.get_id(:name => hostgroup)
-    if search_hostgroup.nil?
+    if search_hostgroup.nil? and hostgroup_create == 1
+        zbx.hostgroups.create(:name => hostgroup)
+        search_hostgroup = zbx.hostgroups.get_id(:name => hostgroup)
+    elsif search_hostgroup.nil? and hostgroup_create == 0
         raise Puppet::Error, "The hostgroup (" + hostgroup + ") does not exist in zabbix. Please use the correct one."
     end
 

--- a/lib/puppet/provider/zabbix_template/ruby.rb
+++ b/lib/puppet/provider/zabbix_template/ruby.rb
@@ -1,0 +1,94 @@
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'zabbix'))
+Puppet::Type.type(:zabbix_template).provide(:ruby, :parent => Puppet::Provider::Zabbix) do
+
+ def create
+    zabbix_url = @resource[:zabbix_url]
+
+    if zabbix_url != ''
+        self.class.require_zabbix
+    end
+        
+    # Set some vars
+    template_name = @resource[:template_name]
+    template_source = @resource[:template_source]
+    zabbix_url = @resource[:zabbix_url]
+    zabbix_user = @resource[:zabbix_user]
+    zabbix_pass = @resource[:zabbix_pass]
+    apache_use_ssl = @resource[:apache_use_ssl]
+
+    # Connect to zabbix api
+    zbx = self.class.create_connection(zabbix_url,zabbix_user,zabbix_pass,apache_use_ssl)
+
+    zbx.configurations.import(
+      :format => "xml",
+      :rules => {
+          :applications => {
+            :createMissing => true,
+            :updateExisting => true
+          },
+          :discoveryRules => {
+            :createMissing => true,
+            :updateExisting => true
+          },
+          :graphs =>{
+            :createMissing => true,
+            :updateExisting => true
+          },
+          :groups => {
+            :createMissing => true
+          },
+          :image => {
+            :createMissing => true,
+            :updateExisting => true
+          },
+          :items => {
+            :createMissing => true,
+            :updateExisting => true
+          },
+          :maps => {
+            :createMissing => true,
+            :updateExisting => true
+          },
+          :screens => {
+            :createMissing => true,
+            :updateExisting => true
+          },
+          :templateLinkage => {
+            :createMissing => true
+          },
+          :templates => {
+            :createMissing => true,
+            :updateExisting => true
+          },
+          :templateScreens => {
+            :createMissing => true,
+            :updateExisting => true
+          },
+          :triggers => {
+            :createMissing => true,
+            :updateExisting => true
+          }
+      },
+      :source => template_source
+    )
+  end
+
+  def exists?
+    zabbix_url = @resource[:zabbix_url]
+
+    if zabbix_url != ''
+        self.class.require_zabbix
+    end
+
+    template_name = @resource[:template_name]
+    template_source = @resource[:template_source]
+    zabbix_user = @resource[:zabbix_user]
+    zabbix_pass = @resource[:zabbix_pass]
+    apache_use_ssl = @resource[:apache_use_ssl]
+
+    zbx = self.class.create_connection(zabbix_url,zabbix_user,zabbix_pass,apache_use_ssl)
+    self.class.check_template_is_equal(template_name,template_source,zabbix_url,zabbix_user,zabbix_pass,apache_use_ssl)
+
+  end
+
+end

--- a/lib/puppet/type/zabbix_host.rb
+++ b/lib/puppet/type/zabbix_host.rb
@@ -25,6 +25,10 @@ Puppet::Type.newtype(:zabbix_host) do
     desc 'Name of the hostgroup.'
   end
 
+  newparam(:group_create) do
+    desc 'Create hostgroup if missing.'
+  end
+
   newparam(:templates) do
     desc 'List of templates which should be loaded for this host.'
   end

--- a/lib/puppet/type/zabbix_template.rb
+++ b/lib/puppet/type/zabbix_template.rb
@@ -1,0 +1,32 @@
+Puppet::Type.newtype(:zabbix_template) do
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  newparam(:template_name, :namevar => true) do
+      desc 'The name of template.'
+  end
+
+  newparam(:template_source) do
+      desc 'Template source file.'
+  end
+
+  newparam(:zabbix_url) do
+      desc 'The url on which the zabbix-api is available.'
+  end
+
+  newparam(:zabbix_user) do
+    desc 'Zabbix-api username.'
+  end
+
+  newparam(:zabbix_pass) do
+      desc 'Zabbix-api password.'
+  end
+
+  newparam(:apache_use_ssl) do
+      desc 'If apache is uses with ssl'
+  end
+end
+

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -172,6 +172,7 @@ class zabbix::agent (
   $monitored_by_proxy    = $zabbix::params::monitored_by_proxy,
   $agent_use_ip          = $zabbix::params::agent_use_ip,
   $zbx_group             = $zabbix::params::agent_zbx_group,
+  $zbx_group_create      = $zabbix::params::agent_zbx_group_create,
   $zbx_templates         = $zabbix::params::agent_zbx_templates,
   $agent_configfile_path = $zabbix::params::agent_configfile_path,
   $pidfile               = $zabbix::params::agent_pidfile,
@@ -239,13 +240,14 @@ class zabbix::agent (
     }
 
     class { 'zabbix::resources::agent':
-      hostname  => $::fqdn,
-      ipaddress => $listen_ip,
-      use_ip    => $agent_use_ip,
-      port      => $listenport,
-      group     => $zbx_group,
-      templates => $zbx_templates,
-      proxy     => $use_proxy,
+      hostname     => $::fqdn,
+      ipaddress    => $listen_ip,
+      use_ip       => $agent_use_ip,
+      port         => $listenport,
+      group        => $zbx_group,
+      group_create => $zbx_group_create,
+      templates    => $zbx_templates,
+      proxy        => $use_proxy,
     }
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -134,6 +134,7 @@ class zabbix::params {
   $monitored_by_proxy             = undef
   $agent_use_ip                   = true
   $agent_zbx_group                = 'Linux servers'
+  $agent_zbx_group_create         = true
   $agent_zbx_templates            = [ 'Template OS Linux', 'Template App SSH Service' ]
   $agent_pidfile                  = '/var/run/zabbix/zabbix_agentd.pid'
   $agent_logfile                  = '/var/log/zabbix/zabbix_agentd.log'

--- a/manifests/resources/agent.pp
+++ b/manifests/resources/agent.pp
@@ -14,13 +14,14 @@
 #
 #
 class zabbix::resources::agent (
-  $hostname  = undef,
-  $ipaddress = undef,
-  $use_ip    = undef,
-  $port      = undef,
-  $group     = undef,
-  $templates = undef,
-  $proxy     = undef,
+  $hostname     = undef,
+  $ipaddress    = undef,
+  $use_ip       = undef,
+  $port         = undef,
+  $group        = undef,
+  $group_create = undef,
+  $templates    = undef,
+  $proxy        = undef,
 ) {
 
   @@zabbix_host { $hostname:
@@ -28,6 +29,7 @@ class zabbix::resources::agent (
     use_ip         => $use_ip,
     port           => $port,
     group          => $group,
+    group_create   => $group_create,
     templates      => $templates,
     proxy          => $proxy,
     zabbix_url     => '',

--- a/manifests/resources/template.pp
+++ b/manifests/resources/template.pp
@@ -1,0 +1,28 @@
+# == Class zabbix::resources::template
+#
+# This will create an resources into puppetdb
+# for automatically configuring agent into
+# zabbix front-end.
+#
+# === Requirements
+#
+# Nothing.
+#
+# When manage_resource is set to true, this class
+# will be loaded from 'zabbix::template'. So no need
+# for loading this class manually.
+#
+#
+define zabbix::resources::template (
+  $template_name = $title,
+  $template_source,
+) {
+
+  @@zabbix_template { "${template_name}":
+    template_source => $template_source,
+    zabbix_url      => '',
+    zabbix_user     => '',
+    zabbix_pass     => '',
+    apache_use_ssl  => '',
+  }
+}

--- a/manifests/resources/web.pp
+++ b/manifests/resources/web.pp
@@ -29,6 +29,12 @@ class zabbix::resources::web (
       Package['zabbixapi'],
     ],
   } ->
+  Zabbix_template <<| |>> {
+    zabbix_url     => $zabbix_url,
+    zabbix_user    => $zabbix_user,
+    zabbix_pass    => $zabbix_pass,
+    apache_use_ssl => $apache_use_ssl,
+  } ->
   Zabbix_host <<| |>> {
     zabbix_url     => $zabbix_url,
     zabbix_user    => $zabbix_user,

--- a/manifests/template.pp
+++ b/manifests/template.pp
@@ -1,0 +1,10 @@
+define zabbix::template (
+  $templ_name   = $title,
+  $templ_source = '',
+) {
+
+  zabbix::resources::template { "${templ_name}":
+    template_name   => $templ_name,
+    template_source => $templ_source,
+  }
+}


### PR DESCRIPTION
Implemented zabbix templates import.
Import is idempotent, template being imported is compared with template with the same name exported from zabbix server. At this point there is no template destroy option.
Also pull request include option to create hostgroup if it is missing, which defaults to true in params.