### PR TITLE
Add "eno*" to interface name matching

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -216,7 +216,7 @@ class zabbix::agent (
   # can find the ipaddress of this specific interface if listenip
   # is set to for example "eth1" or "bond0.73".
   if ($listenip != undef) {
-    if ($listenip =~ /^(eth|bond|lxc).*/) {
+    if ($listenip =~ /^(eth|bond|lxc|eno).*/) {
       $int_name = "ipaddress_${listenip}"
       $listen_ip = inline_template('<%= scope.lookupvar(int_name) %>')
     } elsif is_ip_address($listenip) {


### PR DESCRIPTION
This will fix issue with RHEL7 servers having "eno167800..." names for interfaces