### PR TITLE
Pass manage_repo and zabbix_repo to repo.pp and prevent double include

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -251,10 +251,15 @@ class zabbix::agent (
     }
   }
 
-  # Check if manage_repo is true.
-  if $manage_repo {
-    include zabbix::repo
-    Package['zabbix-agent'] {require => Class['zabbix::repo']}
+  # Only include the repo class if it has not yet been included
+  unless defined(Class['Zabbix::Repo']) {
+    class {'zabbix::repo':
+      manage_repo    => $manage_repo,
+      zabbix_version => $zabbix_version,
+    }
+    Package['zabbix-agent'] {
+      require => Class['zabbix::repo']
+    }
   }
 
   # Installing the package

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -205,6 +205,7 @@ class zabbix (
     database_path           => $database_path,
     zabbix_version          => $zabbix_version,
     manage_firewall         => $manage_firewall,
+    manage_repo             => $manage_repo,
     nodeid                  => $nodeid,
     listenport              => $listenport,
     sourceip                => $sourceip,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -168,6 +168,7 @@ class zabbix (
   class { 'zabbix::web':
     zabbix_url                               => $zabbix_url,
     database_type                            => $database_type,
+    manage_repo                              => $manage_repo,
     zabbix_version                           => $zabbix_version,
     zabbix_timezone                          => $zabbix_timezone,
     manage_vhost                             => $manage_vhost,

--- a/manifests/javagateway.pp
+++ b/manifests/javagateway.pp
@@ -62,10 +62,15 @@ class zabbix::javagateway(
   validate_bool($manage_firewall)
   validate_bool($manage_repo)
 
-  # Check if manage_repo is true.
-  if $manage_repo {
-    include zabbix::repo
-    Package['zabbix-java-gateway'] {require => Class['zabbix::repo']}
+  # Only include the repo class if it has not yet been included
+  unless defind(Class['Zabbix::Repo']) {
+    class { 'zabbix::repo':
+      manage_repo    => $manage_repo,
+      zabbix_version => $zabbix_version,
+    }
+    Package['zabbix-java-gateway'] {
+      require => Class['zabbix::repo']
+    }
   }
 
   # Installing the package

--- a/manifests/proxy.pp
+++ b/manifests/proxy.pp
@@ -450,10 +450,15 @@ class zabbix::proxy (
     }
   }
 
-  # Check if manage_repo is true.
-  if $manage_repo {
-    include zabbix::repo
-    Package["zabbix-proxy-${db}"] {require => Class['zabbix::repo']}
+  # Only include the repo class if it has not yet been included
+  unless defind(Class['Zabbix::Repo']) {
+    class { 'zabbix::repo':
+      manage_repo    => $manage_repo,
+      zabbix_version => $zabbix_version,
+    }
+    Package["zabbix-proxy-${db}"] {
+      require => Class['zabbix::repo']
+    }
   }
 
   # Now we are going to install the correct packages.

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -22,6 +22,9 @@
 #   This is the zabbix version.
 #   Example: 2.4
 #
+# [*manage_repo*]
+#   When true (default) this module will manage the Zabbix repository
+#
 # [*zabbix_package_state*]
 #   The state of the package that needs to be installed: present or latest.
 #   Default: present
@@ -263,6 +266,7 @@ class zabbix::server (
   $zabbix_version          = $zabbix::params::zabbix_version,
   $zabbix_package_state    = $zabbix::params::zabbix_package_state,
   $manage_firewall         = $zabbix::params::manage_firewall,
+  $manage_repo             = $zabbix::params::manage_repo,
   $server_configfile_path  = $zabbix::params::server_configfile_path,
   $server_config_owner     = $zabbix::params::server_config_owner,
   $server_config_group     = $zabbix::params::server_config_group,
@@ -336,7 +340,7 @@ class zabbix::server (
     zabbix_version => $zabbix_version,
     manage_repo    => $manage_repo,
   }
-  
+
   # Check some if they are boolean
   validate_bool($manage_firewall)
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -336,9 +336,12 @@ class zabbix::server (
   $loadmodule              = $zabbix::params::server_loadmodule,
   ) inherits zabbix::params {
 
-  class { 'zabbix::repo':
-    zabbix_version => $zabbix_version,
-    manage_repo    => $manage_repo,
+  # Only include the repo class if it has not yet been included
+  unless defined(Class['Zabbix::Repo']) {
+    class { 'zabbix::repo':
+      zabbix_version => $zabbix_version,
+      manage_repo    => $manage_repo,
+    }
   }
 
   # Check some if they are boolean

--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -19,6 +19,9 @@
 #   - postgresql
 #   - mysql
 #
+# [*manage_repo*]
+#   When true, it will create repository for installing the webinterface.
+#
 # [*zabbix_version*]
 #   This is the zabbix version.
 #   Example: 2.4
@@ -148,6 +151,7 @@
 class zabbix::web (
   $zabbix_url                               = '',
   $database_type                            = $zabbix::params::database_type,
+  $manage_repo                              = $zabbix::params::manage_repo,
   $zabbix_version                           = $zabbix::params::zabbix_version,
   $zabbix_timezone                          = $zabbix::params::zabbix_timezone,
   $zabbix_package_state                     = $zabbix::params::zabbix_package_state,
@@ -180,7 +184,13 @@ class zabbix::web (
   $apache_php_always_populate_raw_post_data = $zabbix::params::apache_php_always_populate_raw_post_data,
 ) inherits zabbix::params {
 
-  include zabbix::repo
+  # Only include the repo class if it has not yet been included
+  unless defined(Class['Zabbix::Repo']) {
+    class { 'zabbix::repo':
+      manage_repo    => $manage_repo,
+      zabbix_version => $zabbix_version,
+    }
+  }
 
   # use the correct db.
   case $database_type {


### PR DESCRIPTION
All classes which call zabbix::repo should pass manage_repo and zabbix_version to zabbix::repo.
To prevent double includes the classes will check if zabbix::repo has already been included.
Instead of checking if the zabbix::repo class should be included (if $manage_repo) the class will be included either way and zabbix::repo will decide if it manages the repositories.