### PR TITLE
Make template dir a paramater

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -134,7 +134,8 @@ class zabbix::params {
   $server_include                 = '/etc/zabbix/zabbix_server.conf.d'
   $server_loadmodulepath          = '/usr/lib/modules'
   $server_loadmodule              = undef
-
+  $server_templatedir             = '/etc/zabbix/imported_templates'
+  
   # Agent specific params
   $agent_configfile_path          = '/etc/zabbix/zabbix_agentd.conf'
   $monitored_by_proxy             = undef

--- a/manifests/resources/template.pp
+++ b/manifests/resources/template.pp
@@ -16,9 +16,10 @@
 define zabbix::resources::template (
   $template_name   = $title,
   $template_source = '',
+  $template_dir    = $zabbix::params::server_templatedir,
 ) {
 
-  file { "/etc/zabbix/templates/${template_name}.xml":
+  file { "${template_dir}/${template_name}.xml":
     ensure => present,
     owner  => 'zabbix',
     group  => 'zabbix',
@@ -27,11 +28,11 @@ define zabbix::resources::template (
 
   @@zabbix_template { $template_name:
     #template_source => $template_source,
-    template_source => "/etc/zabbix/templates/${template_name}.xml",
+    template_source => "${template_dir}/${template_name}.xml",
     zabbix_url      => '',
     zabbix_user     => '',
     zabbix_pass     => '',
     apache_use_ssl  => '',
-    require         => File["/etc/zabbix/templates/${template_name}.xml"]
+    require         => File["${template_dir}/${template_name}.xml"]
   }
 }


### PR DESCRIPTION
The path /etc/zabbix/templates doesn't exist on my install and is instead /etc/zabbix/imported_templates. This make that path a passed parameter. 