### PR TITLE
add support for CloudLinux

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -80,7 +80,7 @@ class zabbix::repo(
     }
 
     case $::operatingsystem {
-      'centos','scientific','redhat','oraclelinux','amazon' : {
+      'centos','scientific','redhat','oraclelinux','amazon','CloudLinux' : {
         yumrepo { 'zabbix':
           name     => "Zabbix_${majorrelease}_${::architecture}",
           descr    => "Zabbix_${majorrelease}_${::architecture}",

--- a/metadata.json
+++ b/metadata.json
@@ -30,6 +30,7 @@
     { "operatingsystem":"CentOS", "operatingsystemrelease": [ "5.0", "6.0", "7.0" ] },
     { "operatingsystem":"XenServer", "operatingsystemrelease": [ "6.0"] },
     { "operatingsystem":"Ubuntu", "operatingsystemrelease": [ "12.04", "14.04" ] },
-    { "operatingsystem":"Debian", "operatingsystemrelease": [ "6.0", "7.0", "8.0" ]  }
+    { "operatingsystem":"Debian", "operatingsystemrelease": [ "6.0", "7.0", "8.0" ]  },
+    { "operatingsystem":"CloudLinux", "operatingsystemrelease": [ "6.0", "7.0" ]  }
    ]
 }


### PR DESCRIPTION
this is a normal centos fork, we just need to adjust the repo detection
for this module to work:

```
# facter -p operatingsystem operatingsystemrelease
operatingsystem => CloudLinux
operatingsystemrelease => 6.6
```