### PR TITLE
Fping wrong path in debian

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,6 +19,12 @@ class zabbix::params {
         $proxy_fpinglocation      = '/usr/bin/fping'
         $proxy_fping6location     = '/usr/bin/fping6'
     }
+    'debian': {
+        $server_fpinglocation     = '/usr/bin/fping'
+        $server_fping6location    = '/usr/bin/fping6'
+        $proxy_fpinglocation      = '/usr/bin/fping'
+        $proxy_fping6location     = '/usr/bin/fping6'
+    }
     default: {
         $server_fpinglocation     = '/usr/sbin/fping'
         $server_fping6location    = '/usr/sbin/fping6'


### PR DESCRIPTION
I fixed the path to fping for Debian system.
Test on :
- 8
- 7
- 6 

Regards.