### PR TITLE
refactoring of repo.pp

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,6 +19,12 @@ class zabbix::params {
         $proxy_fpinglocation      = '/usr/bin/fping'
         $proxy_fping6location     = '/usr/bin/fping6'
     }
+    'debian': {
+        $server_fpinglocation     = '/usr/bin/fping'
+        $server_fping6location    = '/usr/bin/fping6'
+        $proxy_fpinglocation      = '/usr/bin/fping'
+        $proxy_fping6location     = '/usr/bin/fping6'
+    }
     default: {
         $server_fpinglocation     = '/usr/sbin/fping'
         $server_fping6location    = '/usr/sbin/fping6'

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -17,7 +17,9 @@
 #
 # === Authors
 #
-# Author Name: ikben@werner-dijkerman.nl
+# Author Name:
+#   ikben@werner-dijkerman.nl
+#   Tim Meusel <tim@bastelfreak.de>
 #
 # === Copyright
 #
@@ -29,132 +31,70 @@ class zabbix::repo(
 ) inherits zabbix::params {
 
   if ($manage_repo) {
-    # Figuring out which major release we have. Or which release name
-    # for debian/ununtu releases.
-    case $::operatingsystemrelease {
-      /^14.04/: {
-        $majorrelease = '14'
-        $ubuntu       = 'trusty'
-      }
-      /^12.04/: {
-        $majorrelease = '12'
-        $ubuntu       = 'precise'
-      }
-      /^10.04/: {
-        $majorrelease = '10'
-        $ubuntu       = 'lucid'
-      }
-      /^8.*/: {
-        $majorrelease = '8'
-        $debian       = 'jessie'
-      }
-      /^7.*/: {
-        $majorrelease = '7'
-        $debian       = 'wheezy'
-      }
-      /^6.*/: {
+    case $::operatingsystem {
+      'PSBM':  {
         $majorrelease = '6'
-        $debian       = 'squeeze'
-      }
-      /^5.*/: {
-        $majorrelease = '5'
-        $debian       = 'lenny'
-      }
-      # Debian unstable releases look something like "jessie/sid"
-      # In this case, just use the first bit as the version
-      /\/sid$/: {
-        # Zabbix repo doesn't yet support jessie, use wheezy instead
-        if ($::operatingsystemrelease == 'jessie/sid') {
-          $debian = 'wheezy'
-        } else {
-          $debian = regsubst($::operatingsystemrelease, '/sid$', '')
-        }
-      }
-      # Amazon Linux using epel 6
-      /^20??.??/: {
-        $majorrelease = '6'
+        $reponame     = $majorrelease
       }
       default: {
-        fail("This is an unsupported operating system (${::operatingsystem} ${::operatingsystemrelease})")
+        $majorrelease = '$releasever'
+        $reponame     = $::operatingsystemmajrelease
       }
     }
-
-    case $::operatingsystem {
-      'centos','scientific','redhat','oraclelinux','amazon' : {
+    case $::operatingsystemrelease {
+      /\/sid$/: {
+        $releasename = regsubst($::operatingsystemrelease, '/sid$', '')
+      }
+      default: {
+        $releasename = $::lsbdistcodename
+      }
+    }
+    case $::osfamily {
+      'RedHat' : {
         yumrepo { 'zabbix':
-          name     => "Zabbix_${majorrelease}_${::architecture}",
-          descr    => "Zabbix_${majorrelease}_${::architecture}",
-          baseurl  => "http://repo.zabbix.com/zabbix/${zabbix_version}/rhel/${majorrelease}/${::architecture}/",
+          name     => "Zabbix_${reponame}_${::architecture}",
+          descr    => "Zabbix_${reponame}_${::architecture}",
+          baseurl  => "http://repo.zabbix.com/zabbix/${zabbix_version}/rhel/${majorrelease}/\$basearch/",
           gpgcheck => '1',
           gpgkey   => 'http://repo.zabbix.com/RPM-GPG-KEY-ZABBIX',
           priority => '1',
         }
         yumrepo { 'zabbix-nonsupported':
-          name     => "Zabbix_nonsupported_${majorrelease}_${::architecture}",
-          descr    => "Zabbix_nonsupported_${majorrelease}_${::architecture}",
-          baseurl  => "http://repo.zabbix.com/non-supported/rhel/${majorrelease}/${::architecture}/",
+          name     => "Zabbix_nonsupported_${reponame}_${::architecture}",
+          descr    => "Zabbix_nonsupported_${reponame}_${::architecture}",
+          baseurl  => "http://repo.zabbix.com/non-supported/rhel/${majorrelease}/\$basearch/",
           gpgcheck => '1',
           gpgkey   => 'http://repo.zabbix.com/RPM-GPG-KEY-ZABBIX',
           priority => '1',
         }
 
-      } # END 'centos','redhat','oraclelinux'
-      'XenServer' : {
-        yumrepo { 'zabbix':
-          name     => "Zabbix_${majorrelease}_${::architecture}",
-          descr    => "Zabbix_${majorrelease}_${::architecture}",
-          baseurl  => "http://repo.zabbix.com/zabbix/${zabbix_version}/rhel/5/${::architecture}/",
-          gpgcheck => '1',
-          gpgkey   => 'http://repo.zabbix.com/RPM-GPG-KEY-ZABBIX',
-          priority => '1',
-        }
-        yumrepo { 'zabbix-nonsupported':
-          name     => "Zabbix_nonsupported_${majorrelease}_${::architecture}",
-          descr    => "Zabbix_nonsupported_${majorrelease}_${::architecture}",
-          baseurl  => "http://repo.zabbix.com/non-supported/rhel/5/${::architecture}/",
-          gpgcheck => '1',
-          gpgkey   => 'http://repo.zabbix.com/RPM-GPG-KEY-ZABBIX',
-          priority => '1',
-        }
-
-      } # END 'XenServer'
-      'debian' : {
+      }
+      'Debian' : {
         if ($::architecture == 'armv6l') {
           apt::source { 'zabbix':
             location => 'http://naizvoru.com/raspbian/zabbix',
-            release  => $debian,
             repos    => 'main',
             key      => {
               'id'     => 'BC274A7EA7FD5DD267C9A18FD54A213C80E871A7',
-              'source' => 'http://naizvoru.com/raspbian/zabbix/conf/boris@steki.net.gpg.key'
+              'source' => 'http://naizvoru.com/raspbian/zabbix/conf/boris@steki.net.gpg.key',
             },
             include  => {
               'src' => false,
-            }
+            },
           }
         } else {
+          $operatingsystem = downcase($::operatingsystem)
           apt::source { 'zabbix':
-            location => "http://repo.zabbix.com/zabbix/${zabbix_version}/debian/",
-            release  => $debian,
+            location => "http://repo.zabbix.com/zabbix/${zabbix_version}/${operatingsystem}/",
             repos    => 'main',
+            release  => $releasename,
             key      => {
               'id'     => 'FBABD5FB20255ECAB22EE194D13D58E479EA5ED4',
-              'source' => 'http://repo.zabbix.com/zabbix-official-repo.key'
+              'source' => 'http://repo.zabbix.com/zabbix-official-repo.key',
             },
           }
         }
-      } # END 'debian'
-      'ubuntu' : {
-        apt::source { 'zabbix':
-          location => "http://repo.zabbix.com/zabbix/${zabbix_version}/ubuntu/",
-          release  => $ubuntu,
-          repos    => 'main',
-          key      => {
-            'id'     => 'FBABD5FB20255ECAB22EE194D13D58E479EA5ED4',
-            'source' => 'http://repo.zabbix.com/zabbix-official-repo.key'
-          },
-        }
-      } # END 'ubuntu'
+      }
       default : {
         fail('Unrecognized operating system for webserver')
       }

--- a/metadata.json
+++ b/metadata.json
@@ -28,8 +28,11 @@
     { "operatingsystem":"OracleLinux", "operatingsystemrelease": [ "5.0", "6.0", "7.0" ] },
     { "operatingsystem":"Scientific", "operatingsystemrelease": [ "5.0", "6.0", "7.0" ] },
     { "operatingsystem":"CentOS", "operatingsystemrelease": [ "5.0", "6.0", "7.0" ] },
+   { "operatingsystem":"CloudLinux", "operatingsystemrelease": [ "5.0", "6.0", "7.0" ] },
     { "operatingsystem":"XenServer", "operatingsystemrelease": [ "6.0"] },
     { "operatingsystem":"Ubuntu", "operatingsystemrelease": [ "12.04", "14.04" ] },
-    { "operatingsystem":"Debian", "operatingsystemrelease": [ "6.0", "7.0", "8.0" ]  }
+    { "operatingsystem":"Debian", "operatingsystemrelease": [ "6.0", "7.0", "8.0" ]  },
+    { "operatingsystem":"PSBM", "operatingsystemrelease": [ "5.0" ]  },
+    { "operatingsystem":"PCS", "operatingsystemrelease": [ "6.0" ]  }
    ]
 }


### PR DESCRIPTION
- use yum variables in repo files ($releasever and $basearch)
- fix $releasever for PSBM
- switch the case for the repos to $::osfamily
- use one repo for all debian like OSes
- use one repo for all RHEL like OSes
- Update sid regex to not exclude jessie ( jessie is now present on the mirror)