### PR TITLE
Added supporting new Zabbix params

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -140,6 +140,9 @@ class zabbix::params {
   $server_include                 = '/etc/zabbix/zabbix_server.conf.d'
   $server_loadmodulepath          = '/usr/lib/modules'
   $server_loadmodule              = undef
+  $server_sslcertlocation         = '/usr/lib/zabbix/ssl/certs'
+  $server_sslkeylocation          = '/usr/lib/zabbix/ssl/keys'
+
 
   # Agent specific params
   $agent_configfile_path          = '/etc/zabbix/zabbix_agentd.conf'

--- a/manifests/resources/agent.pp
+++ b/manifests/resources/agent.pp
@@ -14,14 +14,15 @@
 #
 #
 class zabbix::resources::agent (
-  $hostname     = undef,
-  $ipaddress    = undef,
-  $use_ip       = undef,
-  $port         = undef,
-  $group        = undef,
-  $group_create = undef,
-  $templates    = undef,
-  $proxy        = undef,
+  $hostname      = undef,
+  $ipaddress     = undef,
+  $use_ip        = undef,
+  $port          = undef,
+  $group         = undef,
+  $group_create  = undef,
+  $templates     = undef,
+  $proxy         = undef,
+  $zabbix_server = undef,
 ) {
 
   @@zabbix_host { $hostname:
@@ -36,5 +37,6 @@ class zabbix::resources::agent (
     zabbix_user    => '',
     zabbix_pass    => '',
     apache_use_ssl => '',
+    zabbix_server  => $zabbix_server,
   }
 }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -229,6 +229,12 @@
 # [*loadmodule*]
 #   Module to load at server startup.
 #
+# [*sslcertlocation_dir*]
+#   Location of SSL client certificate files for client authentication.
+# 
+# [*sslkeylocation_dir*]
+#   Location of SSL private key files for client authentication. 
+#
 # === Example
 #
 #   When running everything on a single node, please check
@@ -334,7 +340,10 @@ class zabbix::server (
   $include_dir             = $zabbix::params::server_include,
   $loadmodulepath          = $zabbix::params::server_loadmodulepath,
   $loadmodule              = $zabbix::params::server_loadmodule,
-  ) inherits zabbix::params {
+  $sslcertlocation_dir     = $zabbix::params::server_sslcertlocation,
+  $sslkeylocation_dir      = $zabbix::params::server_sslkeylocation,
+
+) inherits zabbix::params {
 
   # Only include the repo class if it has not yet been included
   unless defined(Class['Zabbix::Repo']) {

--- a/templates/zabbix_server.conf.erb
+++ b/templates/zabbix_server.conf.erb
@@ -367,6 +367,16 @@ AllowRoot=<%= @allowroot %>
 #
 Include=<%= @include_dir %>
 
+### option: SSLCertLocation
+#       location of SSL client certificate files for client authentication.
+#
+SSLCertLocation=<%= @sslcertlocation_dir %>
+
+### option: SSLKeyLocation
+#       location of SSL private key files for client authentication.
+#
+SSLKeyLocation=<%= @sslkeylocation_dir %>
+
 ####### loadable modules #######
 <% if @zabbix_version == '2.2' or @zabbix_version == '2.4' %>
 ### option: loadmodulepath


### PR DESCRIPTION
In Zabbix 2.4 added parameter for SSL client certificate. 
SSLCertLocation and SSLKeyLocation
More info 
https://www.zabbix.com/documentation/2.4/manual/appendix/config/zabbix_server