### PR TITLE
Generalise the zabbix_url

### DIFF
--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -152,7 +152,7 @@
 # Copyright 2014 Werner Dijkerman
 #
 class zabbix::web (
-  $zabbix_url                               = '',
+  $zabbix_url                               = $zabbix::params::zabbix_url,
   $database_type                            = $zabbix::params::database_type,
   $manage_repo                              = $zabbix::params::manage_repo,
   $zabbix_version                           = $zabbix::params::zabbix_version,


### PR DESCRIPTION
set the url to inherit from params in order to ease use for hiera, has been done to fix the following error while configuring the url via hiera:

puppet agent -t
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Loading facts
Error: Could not retrieve catalog from remote server: Could not intern from text/pson: Could not intern from data: Could not find relationship target "Apache::Vhost[]"
Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run