### PR TITLE
tap0 or tun0 (OpenVPN interfaces) interface as listenip

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -216,7 +216,7 @@ class zabbix::agent (
   # can find the ipaddress of this specific interface if listenip
   # is set to for example "eth1" or "bond0.73".
   if ($listenip != undef) {
-    if ($listenip =~ /^(eth|bond|lxc|eno).*/) {
+    if ($listenip =~ /^(eth|bond|lxc|eno|tap|tun).*/) {
       $int_name = "ipaddress_${listenip}"
       $listen_ip = inline_template('<%= scope.lookupvar(int_name) %>')
     } elsif is_ip_address($listenip) {


### PR DESCRIPTION
Make it possible to set an tap0 or tun0 (OpenVPN interfaces) interface as listenip.