### PR TITLE
enable apache_php_max_input_vars

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -58,6 +58,7 @@ class zabbix::params {
   $apache_php_upload_max_filesize           = '2M'
   $apache_php_max_input_time                = '300'
   $apache_php_always_populate_raw_post_data = '-1'
+  $apache_php_max_input_vars                = 1000,
 
   # Zabbix-web
   $apache_use_ssl                 = false

--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -124,6 +124,9 @@
 # [*apache_php_always_populate_raw_post_data*]
 #   Default: -1
 #
+# [*apache_php_max_input_vars*]
+#   Max amount of vars for GET/POST requests
+#
 # === Example
 #
 #   When running everything on a single node, please check
@@ -186,6 +189,7 @@ class zabbix::web (
   $apache_php_upload_max_filesize           = $zabbix::params::apache_php_upload_max_filesize,
   $apache_php_max_input_time                = $zabbix::params::apache_php_max_input_time,
   $apache_php_always_populate_raw_post_data = $zabbix::params::apache_php_always_populate_raw_post_data,
+  $apache_php_max_input_vars                = $zabbix::params::apache_php_max_input_vars,
 ) inherits zabbix::params {
 
   # Only include the repo class if it has not yet been included
@@ -379,6 +383,7 @@ class zabbix::web (
    php_value upload_max_filesize ${apache_php_upload_max_filesize}
    php_value max_input_time ${apache_php_max_input_time}
    php_value always_populate_raw_post_data ${apache_php_always_populate_raw_post_data}
+   php_value max_input_vars ${apache_php_max_input_vars}
    # Set correct timezone
    php_value date.timezone ${zabbix_timezone}",
       rewrites        => [


### PR DESCRIPTION
This adds the param apache_php_max_input_vars to the zabbix::web class.
It will allow us to configure the amount of max input vars for GET/POST
requests. On large installations you need 2000 or more vars on mass
updates. 1000 is the default value on CentOS which gets set in the
zabbix::params.pp