### PR TITLE
fixed SSL server template options for 2.2

### DIFF
--- a/templates/zabbix_server.conf.erb
+++ b/templates/zabbix_server.conf.erb
@@ -367,6 +367,7 @@ AllowRoot=<%= @allowroot %>
 #
 Include=<%= @include_dir %>
 
+<% if @zabbix_version == '2.4' %>
 ### option: SSLCertLocation
 #       location of SSL client certificate files for client authentication.
 #
@@ -376,6 +377,7 @@ SSLCertLocation=<%= @sslcertlocation_dir %>
 #       location of SSL private key files for client authentication.
 #
 SSLKeyLocation=<%= @sslkeylocation_dir %>
+<% end %>
 
 ####### loadable modules #######
 <% if @zabbix_version == '2.2' or @zabbix_version == '2.4' %>


### PR DESCRIPTION
SSLCertLocation and SSLKeyLocation were introduced with 2.4 and aren't compatible with 2.2, resulting in the server refusing to start due to unknown options.

https://www.zabbix.com/documentation/2.4/manual/introduction/whatsnew240#ssl_verification_and_authentication_options