### PR TITLE
allow serveractive to be optional

### DIFF
--- a/templates/zabbix_agentd.conf.erb
+++ b/templates/zabbix_agentd.conf.erb
@@ -98,8 +98,9 @@ StartAgents=<%= @startagents %>
 #       if this parameter is not specified, active checks are disabled.
 #       example: serveractive=127.0.0.1:20051,zabbix.domain,[::1]:30051,::1,[12fc::1]
 #
+<% if @serveractive -%>
 ServerActive=<%= @serveractive %>
-
+<% end -%>
 
 ### option: hostname
 #       unique, case sensitive hostname.


### PR DESCRIPTION
server active gives errors if used on agents that aren't using active agent calls, this prevents active check configuration update from [127.0.0.1:10051] started to fail (cannot connect to [[127.0.0.1]:10051]: [111] Connection refused) from occurring