### PR TITLE
Allow agent_serveractive value to be blank

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -163,7 +163,7 @@ class zabbix::params {
   $agent_listenport               = '10050'
   $agent_listenip                 = undef
   $agent_startagents              = '3'
-  $agent_serveractive             = '127.0.0.1'
+  $agent_serveractive             = undef
   $agent_hostname                 = undef
   $agent_hostnameitem             = 'system.hostname'
   $agent_hostmetadata             = undef


### PR DESCRIPTION
to prevent  10832:20160120:225723.336 active check configuration update from [127.0.0.1:10051] started to fail (cannot connect to [[127.0.0.1]:10051]: [111] Connection refused) from occurring on agents