### PR TITLE
Added zabbix_template_host type

### DIFF
--- a/lib/puppet/provider/zabbix_template_host/ruby.rb
+++ b/lib/puppet/provider/zabbix_template_host/ruby.rb
@@ -1,0 +1,52 @@
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'zabbix'))
+Puppet::Type.type(:zabbix_template_host).provide(:ruby, :parent => Puppet::Provider::Zabbix) do
+
+  def template_name
+    return @template_name ||= @resource[:name].split('@')[0]
+  end
+
+  def template_id
+    zbx = connect
+    return @template_id ||= zbx.templates.get_id(:host => template_name)
+  end
+
+  def hostname
+    return @hostname ||= @resource[:name].split('@')[1]
+  end
+
+  def hostid
+    zbx = connect
+    return @hostid ||= zbx.hosts.get_id(:host => hostname)
+  end
+
+  def connect
+    if @resource[:zabbix_url] != ''
+      self.class.require_zabbix
+    end
+
+    @zbx ||= self.class.create_connection(@resource[:zabbix_url],@resource[:zabbix_user],@resource[:zabbix_pass],@resource[:apache_use_ssl])
+    return @zbx
+  end
+
+  def create
+    zbx = connect
+    zbx.templates.mass_add(
+      :hosts_id     => [hostid],
+      :templates_id => [template_id]
+    )
+  end
+
+  def exists?
+    zbx = connect
+    zbx.templates.get_ids_by_host(:hostids => [hostid]).include?(template_id.to_s)
+  end
+
+  def destroy
+    zbx = connect
+    zbx.templates.mass_remove(
+      :hosts_id     => [hostid],
+      :templates_id => [template_id]
+    )
+  end
+
+end

--- a/lib/puppet/type/zabbix_template_host.rb
+++ b/lib/puppet/type/zabbix_template_host.rb
@@ -1,0 +1,34 @@
+require 'puppet/util/zabbix'
+
+Puppet::Type.newtype(:zabbix_template_host) do
+
+  @doc = %q{Link or Unlink template to host.
+	  Example.
+	  Name should be in the format of "template_name@hostname"
+
+	  zabbix_template_host{"mysql_template@db1":
+            ensure => present
+          }
+  }
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  newparam(:name, :namevar => true) do
+      newvalues(/.+\@.+/)
+      desc 'template_name@host_name'
+  end
+
+Puppet::Util::Zabbix.add_zabbix_type_methods(self)
+
+  autorequire(:zabbix_host) do
+    self[:name].split('@')[1]
+  end
+
+  autorequire(:zabbix_template) do
+    self[:name].split('@')[0]
+  end
+
+end


### PR DESCRIPTION
This new type can be used to link/unlink template to the host. zabbix_host
provide a way to assign list of templates while creating the host. But in
a scenario where:
* One need to add zabbix_host from agent setup code
* Link appropriate templates from the service setup code. For example, mysql server
deployment code can use below code to link the template "Template App MySQL" to the host.

```
zabbix_template_host{"Template App MySQL@${::hostname}": }

```