### PR TITLE
Type to manage zabbix application

### DIFF
--- a/lib/puppet/provider/zabbix_application/ruby.rb
+++ b/lib/puppet/provider/zabbix_application/ruby.rb
@@ -1,0 +1,50 @@
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'zabbix'))
+Puppet::Type.type(:zabbix_application).provide(:ruby, :parent => Puppet::Provider::Zabbix) do
+
+  def connect
+    if @resource[:zabbix_url] != ''
+      self.class.require_zabbix
+    end
+
+    @zbx ||= self.class.create_connection(@resource[:zabbix_url],@resource[:zabbix_user],@resource[:zabbix_pass],@resource[:apache_use_ssl])
+    return @zbx
+  end
+
+  def template_id
+    zbx = connect
+    return @template_id ||= zbx.templates.get_id(:host => @resource[:template])
+  end
+
+  def monhostid
+    zbx = connect
+    return zbx.templates.get_id(:host => 'mon1')
+  end
+
+  def create
+    zbx = connect
+    zbx.applications.create(
+      :name   => @resource[:name],
+      :hostid => template_id
+    )
+  end
+
+  def application_id
+    zbx = connect
+    return @application_id ||= zbx.applications.get_id(:name => @resource[:name])
+  end
+
+  def exists?
+    zbx = connect
+    zbx.applications.get_id(:name => @resource[:name])
+  end
+
+  def destroy
+    zbx = connect
+    begin
+        zbx.applications.delete(application_id)
+    rescue => error
+        raise(Puppet::Error, "Zabbix Application Delete Failed\n#{error.message}")
+    end
+  end
+
+end

--- a/lib/puppet/type/zabbix_application.rb
+++ b/lib/puppet/type/zabbix_application.rb
@@ -1,0 +1,39 @@
+require 'puppet/util/zabbix'
+
+Puppet::Type.newtype(:zabbix_application) do
+
+  @doc = %q{Manage zabbix applications
+
+    Example.
+      Zabbix_application {
+        zabbix_url => 'zabbix_server1',
+        zabbix_user => 'admin',
+        zabbix_pass => 'zabbix',
+      }
+
+      zabbix_application{"app1":
+        ensure   => present,
+        template => 'template1',
+      }
+
+  It Raise exception on deleting an application which is a part of used template.
+
+  }
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  newparam(:name, :namevar => true) do
+    desc 'application name'
+  end
+
+  newparam(:template) do
+    desc "template to which the application is linked"
+  end
+
+  Puppet::Util::Zabbix.add_zabbix_type_methods(self)
+
+end
+


### PR DESCRIPTION
Example:

Zabbix_application {
  zabbix_url => 'zabbix_server1',
  zabbix_user => 'admin',
  zabbix_pass => 'zabbix',
}

zabbix_application{"app1":
  ensure   => present,
  template => 'template1',
}

Note: It Raise exception on deleting an application which is a part of used template.