### PR TITLE
Update proxy.pp, fix Error: ...install zabbix-proxy- ..

### DIFF
--- a/manifests/proxy.pp
+++ b/manifests/proxy.pp
@@ -409,10 +409,21 @@ class zabbix::proxy (
 
   # Get the correct database_type. We need this for installing the
   # correct package and loading the sql files.
+  case $database_type {
+    'postgresql': {
+      $db = 'pgsql'
+    }
+    'mysql': {
+      $db = 'mysql'
+    }
+    'sqlite': {
+      $db = 'sqlite3'
+    }
+  }
+
   if $manage_database == true {
     case $database_type {
       'postgresql': {
-        $db = 'pgsql'
 
         # Execute the postgresql scripts
         class { 'zabbix::database::postgresql':
@@ -428,7 +439,6 @@ class zabbix::proxy (
         }
       }
       'mysql': {
-        $db = 'mysql'
 
         # Execute the mysql scripts
         class { 'zabbix::database::mysql':
@@ -443,9 +453,7 @@ class zabbix::proxy (
           require              => Package["zabbix-proxy-${db}"],
         }
       }
-      'sqlite': {
-        $db = 'sqlite3'
-      }
+
       default: {
         fail("Unrecognized database type for proxy: ${database_type}")
       }


### PR DESCRIPTION
Hi,
thank you for the quick fixing of the issue  Database is always managed #153 
I tried running puppet fix the fix but got:

`Error: Execution of '/usr/bin/apt-get -q -y -o DPkg::Options::=--force-confold install zabbix-proxy-' returned 100: Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package zabbix-proxy
Error: /Stage[main]/Zabbix::Proxy/Package[zabbix-proxy-]/ensure: change from purged to present failed: Execution of '/usr/bin/apt-get -q -y -o DPkg::Options::=--force-confold install zabbix-proxy-' returned 100: Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package zabbix-proxy`

After a quick look into the fix, I saw that there part where db variable is set was not reachable if the database is managed.

So I extracted the file name building depending on DB type to an extra loop.