### PR TITLE
Travis CI setup: ensure all rspec tests pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,18 @@
 language: ruby
 sudo: false
 cache: bundler
-
-rvm:
-  - 2.0.0
-
-script: "bundle exec rake test"
-
-env:
-  matrix:
-    - PUPPET_GEM_VERSION="~> 2.7.0"
-    - PUPPET_GEM_VERSION="~> 3.0"
-    - PUPPET_GEM_VERSION="~> 4.0"
-
 notifications:
-  email:
-    on_failure: change
-    on_success: never
+  email: false
+branches:
+  only:
+    - master
+bundler_args: --without development system_tests
+before_install: rm Gemfile.lock || true
+rvm:
+  - 1.9.3
+  - 2.1.0
+script: "bundle exec rake test"
+env:
+  - PUPPET_GEM_VERSION="~> 3.0" STRICT_VARIABLES=yes
+  - PUPPET_GEM_VERSION="~> 3.0" STRICT_VARIABLES=yes FUTURE_PARSER=yes
+  - PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES=yes

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -219,11 +219,16 @@ class zabbix::agent (
     if ($listenip =~ /^(eth|bond|lxc|eno|tap|tun).*/) {
       $int_name = "ipaddress_${listenip}"
       $listen_ip = inline_template('<%= scope.lookupvar(int_name) %>')
-    } elsif is_ip_address($listenip) or $listenip == '*' {
+    }
+    elsif is_ip_address($listenip) or $listenip == '*' {
       $listen_ip = $listenip
-    } else {
+    }
+    else {
       $listen_ip = $::ipaddress
     }
+  }
+  else {
+    $listen_ip = $::ipaddress
   }
 
   # So if manage_resources is set to true, we can send some data

--- a/manifests/database/mysql.pp
+++ b/manifests/database/mysql.pp
@@ -25,19 +25,21 @@ class zabbix::database::mysql (
   $database_host        = '',
   $database_path        = $zabbix::params::database_path,
 ) {
-# Allow to customize the path to the Database Schema,
-  if ! $database_schema_path {
+  # Allow to customize the path to the Database Schema,
+  if ($database_schema_path == false) or ($database_schema_path == '') {
     case $::operatingsystem {
-      'centos','redhat','oraclelinux' : {
-            $schema_path   = "/usr/share/doc/zabbix-*-mysql-${zabbix_version}*/create"
-          }
-        default : {
-          $schema_path   = '/usr/share/zabbix-*-mysql'
+      'CentOS','RedHat','OracleLinux' : {
+        $schema_path = "/usr/share/doc/zabbix-*-mysql-${zabbix_version}*/create"
+      }
+      default : {
+        $schema_path = '/usr/share/zabbix-*-mysql'
       }
     }
-  }else {
-      $schema_path = $database_schema_path
   }
+  else {
+    $schema_path = $database_schema_path
+  }
+
   # Loading the sql files.
   case $zabbix_type {
     'proxy': {

--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -25,18 +25,19 @@ class zabbix::database::postgresql (
   $database_host        = '',
   $database_path        = $zabbix::params::database_path,
 ) {
-# Allow to customize the path to the Database Schema,
-  if ! $database_schema_path {
+  # Allow to customize the path to the Database Schema,
+  if ($database_schema_path == false) or ($database_schema_path == '') {
     case $::operatingsystem {
-      'centos','redhat','oraclelinux' : {
-            $schema_path   = "/usr/share/doc/zabbix-*-pgsql-${zabbix_version}*/create"
-          }
-        default : {
-            $schema_path   = '/usr/share/zabbix-*-pgsql'
+      'CentOS', 'RedHat', 'OracleLinux': {
+        $schema_path   = "/usr/share/doc/zabbix-*-pgsql-${zabbix_version}*/create"
+      }
+      default : {
+        $schema_path   = '/usr/share/zabbix-*-pgsql'
       }
     }
-  }else {
-      $schema_path = $database_schema_path
+  }
+  else {
+    $schema_path = $database_schema_path
   }
 
 

--- a/manifests/proxy.pp
+++ b/manifests/proxy.pp
@@ -419,6 +419,9 @@ class zabbix::proxy (
     'sqlite': {
       $db = 'sqlite3'
     }
+    default: {
+      fail("Unrecognized database type for proxy: ${database_type}")
+    }
   }
 
   if $manage_database == true {

--- a/spec/classes/agent_spec.rb
+++ b/spec/classes/agent_spec.rb
@@ -1,153 +1,132 @@
 require 'spec_helper'
 
 describe 'zabbix::agent' do
-  let(:node) { 'agent.example.com' }
-  let(:params) { {:server => '192.168.1.1', :serveractive => '192.168.1.1', :agent_configfile_path => '/etc/zabbix/zabbix_agentd.conf'} }
+  let (:node) { 'agent.example.com' }
+  let (:params) do
+    {
+      :server => '192.168.1.1',
+      :serveractive => '192.168.1.1',
+      :agent_configfile_path => '/etc/zabbix/zabbix_agentd.conf',
+    }
+  end
 
-  # Running an RedHat OS.
-  context 'On a RedHat OS' do
-    let :facts do
+  context 'On RedHat 6.5' do
+    let (:facts) do
       {
         :osfamily               => 'RedHat',
         :operatingsystem        => 'RedHat',
         :operatingsystemrelease => '6.5',
         :architecture           => 'x86_64',
         :lsbdistid              => 'RedHat',
-        :concat_basedir         => '/tmp'
+        :concat_basedir         => '/tmp',
       }
     end
 
-  # Need the zabbix::repo?
-  context "when declaring manage_repo is true" do
-    let(:params) {{ :manage_repo => true }}
-    it { should contain_class('zabbix::repo').with_zabbix_version('2.4') }
-    it { should contain_package('zabbix-agent').with_require('Class[Zabbix::Repo]')}
-  end
+    # Make sure package will be installed, service running and ensure of directory.
+    it { should contain_package('zabbix-agent').with_ensure('present') }
+    it { should contain_package('zabbix-agent').with_name('zabbix-agent') }
+  
+    it { should contain_service('zabbix-agent').with_ensure('running') }
+    it { should contain_service('zabbix-agent').with_name('zabbix-agent') }
+  
+    it { should contain_file('/etc/zabbix/zabbix_agentd.d').with_ensure('directory') }
 
-  context "when declaring manage_resources is true" do
-    let(:params) {{ :manage_resources => true }}
-    it { should contain_class('zabbix::resources::agent') }
-  end
+    context "when declaring manage_repo is true" do
+      let (:params) do
+        {
+          :manage_repo => true,
+        }
+      end
 
-  # Make sure package will be installed, service running and ensure of directory.
-  it { should contain_package('zabbix-agent').with_ensure('present') }
-  it { should contain_package('zabbix-agent').with_name('zabbix-agent') }
+      it { should contain_class('zabbix::repo').with_zabbix_version('2.4') }
+      it { should contain_package('zabbix-agent').with_require('Class[Zabbix::Repo]')}
+    end
+  
+    context "when declaring manage_resources is true" do
+      let (:params) do
+        {
+          :manage_resources => true,
+        }
+      end
 
-  it { should contain_service('zabbix-agent').with_ensure('running') }
-  it { should contain_service('zabbix-agent').with_name('zabbix-agent') }
+      it { should contain_class('zabbix::resources::agent') }
+    end
 
-  it { should contain_file('/etc/zabbix/zabbix_agentd.d').with_ensure('directory') }
+    context "configuration file with hostnameitem" do
+      let (:params) do
+        {
+          :hostnameitem => 'system.hostname',
+        }
+      end
 
-  # Configuration file
-  context 'with pidfile => /var/run/zabbix/zabbix_agentd.pid' do
-      let(:params) { {:pidfile => '/var/run/zabbix/zabbix_agentd.pid', :agent_configfile_path => '/etc/zabbix/zabbix_agentd.conf'} }
-      it {should contain_file('/etc/zabbix/zabbix_agentd.conf').with_content %r{^PidFile=/var/run/zabbix/zabbix_agentd.pid$}}
-  end
-
-  context 'with logfile => /var/run/zabbix/zabbix_agentd.pid' do
-      let(:params) { {:logfile => '/var/log/zabbix/zabbix_agentd.log', :agent_configfile_path => '/etc/zabbix/zabbix_agentd.conf'} }
-      it {should contain_file('/etc/zabbix/zabbix_agentd.conf').with_content %r{^LogFile=/var/log/zabbix/zabbix_agentd.log$}}
-  end
-
-  context 'with DebugLevel => 4' do
-      let(:params) { {:debuglevel => '4', :agent_configfile_path => '/etc/zabbix/zabbix_agentd.conf'} }
-      it {should contain_file('/etc/zabbix/zabbix_agentd.conf').with_content %r{^DebugLevel=4$}}
-  end
-
-  context 'with logfilesize => 4' do
-      let(:params) { {:logfilesize => '4', :agent_configfile_path => '/etc/zabbix/zabbix_agentd.conf'} }
-      it {should contain_file('/etc/zabbix/zabbix_agentd.conf').with_content %r{^LogFileSize=4$}}
-  end
-
-  context 'with EnableRemoteCommands => 1' do
-      let(:params) { {:enableremotecommands => '1', :agent_configfile_path => '/etc/zabbix/zabbix_agentd.conf'} }
-      it {should contain_file('/etc/zabbix/zabbix_agentd.conf').with_content %r{^EnableRemoteCommands=1$}}
-  end
-
-  context 'with LogRemoteCommands => 0' do
-      let(:params) { {:logremotecommands => '0', :agent_configfile_path => '/etc/zabbix/zabbix_agentd.conf'} }
-      it { should contain_file('/etc/zabbix/zabbix_agentd.conf').with_content %r{^LogRemoteCommands=0$}}
-  end
-
-  context 'with server => 192.168.1.1' do
-      let(:params) { {:server => '192.168.1.1', :agent_configfile_path => '/etc/zabbix/zabbix_agentd.conf'} }
-      it {should contain_file('/etc/zabbix/zabbix_agentd.conf').with_content %r{^Server=192.168.1.1$}}
-  end
-
-  context 'with ListenPort => 10050' do
-      let(:params) { {:listenport => '10050', :agent_configfile_path => '/etc/zabbix/zabbix_agentd.conf'} }
-      it {should contain_file('/etc/zabbix/zabbix_agentd.conf').with_content %r{^ListenPort=10050$}}
-  end
-
-  context 'with StartAgents => 3' do
-      let(:params) { {:startagents => '3', :agent_configfile_path => '/etc/zabbix/zabbix_agentd.conf'} }
-      it {should contain_file('/etc/zabbix/zabbix_agentd.conf').with_content %r{^StartAgents=3$}}
-  end
-
-  context 'with ServerActive => 192.168.1.1' do
-      let(:params) { {:serveractive => '192.168.1.1', :agent_configfile_path => '/etc/zabbix/zabbix_agentd.conf'} }
-      it {should contain_file('/etc/zabbix/zabbix_agentd.conf').with_content %r{^ServerActive=192.168.1.1$}}
-  end
-
-  context 'with Hostname => 192.168.1.1' do
-      let(:params) { {:hostname => '10050', :agent_configfile_path => '/etc/zabbix/zabbix_agentd.conf'} }
-      it {should contain_file('/etc/zabbix/zabbix_agentd.conf').with_content %r{^Hostname=10050$}}
-  end
-
-  context 'with HostnameItem => system.hostname' do
-      let(:params) { {:hostnameitem => 'system.hostname', :agent_configfile_path => '/etc/zabbix/zabbix_agentd.conf'} }
       it {should contain_file('/etc/zabbix/zabbix_agentd.conf').with_content %r{^HostnameItem=system.hostname$}}
-  end
+    end
 
-  context 'with RefreshActiveChecks => 120' do
-      let(:params) { {:refreshactivechecks => '120', :agent_configfile_path => '/etc/zabbix/zabbix_agentd.conf'} }
-      it {should contain_file('/etc/zabbix/zabbix_agentd.conf').with_content %r{^RefreshActiveChecks=120$}}
-  end
+    context "when declaring manage_firewall is true" do
+      let (:params) do
+        {
+          :manage_firewall => true,
+        }
+      end
+
+      it { should contain_firewall('150 zabbix-agent') }
+    end
   
-  context 'with BufferSend => 5' do
-      let(:params) { {:buffersend => '5', :agent_configfile_path => '/etc/zabbix/zabbix_agentd.conf'} }
-      it {should contain_file('/etc/zabbix/zabbix_agentd.conf').with_content %r{^BufferSend=5$}}
-  end
+    context "when declaring manage_firewall is false" do
+      let (:params) do
+        {
+          :manage_firewall => false,
+        }
+      end
 
-  context 'with BufferSize => 100' do
-      let(:params) { {:buffersize => '100', :agent_configfile_path => '/etc/zabbix/zabbix_agentd.conf'} }
-      it {should contain_file('/etc/zabbix/zabbix_agentd.conf').with_content %r{^BufferSize=100$}}
-  end
+      it { should_not contain_firewall('150 zabbix-agent') }
+    end
 
-  context 'with Timeout => 30' do
-      let(:params) { {:timeout => '30', :agent_configfile_path => '/etc/zabbix/zabbix_agentd.conf'} }
-      it {should contain_file('/etc/zabbix/zabbix_agentd.conf').with_content %r{^Timeout=30$}}
-  end
+    context "configuration file with full options" do
+      let (:params) do
+        {
+          :allowroot             => '0',
+          :agent_configfile_path => '/etc/zabbix/zabbix_agentd.conf',
+          :buffersend            => '5',
+          :buffersize            => '100',
+          :debuglevel            => '4',
+          :enableremotecommands  => '1',
+          :hostname              => '10050',
+          :include_dir           => '/etc/zabbix/zabbix_agentd.d',
+          :listenport            => '10050',
+          :loadmodulepath        => '${libdir}/modules',
+          :logfilesize           => '4',
+          :logfile               => '/var/log/zabbix/zabbix_agentd.log',
+          :logremotecommands     => '0',
+          :pidfile               => '/var/run/zabbix/zabbix_agentd.pid',
+          :refreshactivechecks   => '120',
+          :server                => '192.168.1.1',
+          :serveractive          => '192.168.1.1',
+          :startagents           => '3',
+          :timeout               => '30',
+          :unsafeuserparameters  => '0',
+        }
+      end
 
-  context 'with AllowRoot => 0' do
-      let(:params) { {:allowroot => '0', :agent_configfile_path => '/etc/zabbix/zabbix_agentd.conf'} }
       it {should contain_file('/etc/zabbix/zabbix_agentd.conf').with_content %r{^AllowRoot=0$}}
-  end
-
-  context 'with Include => /etc/zabbix/zabbix_agentd.d' do
-      let(:params) { {:include_dir => '/etc/zabbix/zabbix_agentd.d', :agent_configfile_path => '/etc/zabbix/zabbix_agentd.conf'} }
+      it {should contain_file('/etc/zabbix/zabbix_agentd.conf').with_content %r{^BufferSend=5$}}
+      it {should contain_file('/etc/zabbix/zabbix_agentd.conf').with_content %r{^BufferSize=100$}}
+      it {should contain_file('/etc/zabbix/zabbix_agentd.conf').with_content %r{^DebugLevel=4$}}
+      it {should contain_file('/etc/zabbix/zabbix_agentd.conf').with_content %r{^EnableRemoteCommands=1$}}
+      it {should contain_file('/etc/zabbix/zabbix_agentd.conf').with_content %r{^Hostname=10050$}}
       it {should contain_file('/etc/zabbix/zabbix_agentd.conf').with_content %r{^Include=/etc/zabbix/zabbix_agentd.d$}}
-  end
-
-  context 'with UnsafeUserParameters => 0' do
-      let(:params) { {:unsafeuserparameters => '0', :agent_configfile_path => '/etc/zabbix/zabbix_agentd.conf'} }
-      it {should contain_file('/etc/zabbix/zabbix_agentd.conf').with_content %r{^UnsafeUserParameters=0$}}
-  end
-
-  context 'with LoadModulePath => ${libdir}/modules' do
-      let(:params) { {:loadmodulepath => '${libdir}/modules', :agent_configfile_path => '/etc/zabbix/zabbix_agentd.conf'} }
+      it {should contain_file('/etc/zabbix/zabbix_agentd.conf').with_content %r{^ListenPort=10050$}}
       it {should contain_file('/etc/zabbix/zabbix_agentd.conf').with_content %r{^LoadModulePath=\$\{libdir\}/modules$}}
-  end
-
-  # Firewall
-  context "when declaring manage_firewall is true" do
-    let(:params) {{ :manage_firewall => true }}
-    it { should contain_firewall('150 zabbix-agent') }
-  end
-  
-  context "when declaring manage_firewall is false" do
-    let(:params) {{ :manage_firewall => false }}
-    it { should_not contain_firewall('150 zabbix-agent') }
-  end
+      it {should contain_file('/etc/zabbix/zabbix_agentd.conf').with_content %r{^LogFileSize=4$}}
+      it {should contain_file('/etc/zabbix/zabbix_agentd.conf').with_content %r{^LogFile=/var/log/zabbix/zabbix_agentd.log$}}
+      it {should contain_file('/etc/zabbix/zabbix_agentd.conf').with_content %r{^LogRemoteCommands=0$}}
+      it {should contain_file('/etc/zabbix/zabbix_agentd.conf').with_content %r{^PidFile=/var/run/zabbix/zabbix_agentd.pid$}}
+      it {should contain_file('/etc/zabbix/zabbix_agentd.conf').with_content %r{^RefreshActiveChecks=120$}}
+      it {should contain_file('/etc/zabbix/zabbix_agentd.conf').with_content %r{^Server=192.168.1.1$}}
+      it {should contain_file('/etc/zabbix/zabbix_agentd.conf').with_content %r{^ServerActive=192.168.1.1$}}
+      it {should contain_file('/etc/zabbix/zabbix_agentd.conf').with_content %r{^StartAgents=3$}}
+      it {should contain_file('/etc/zabbix/zabbix_agentd.conf').with_content %r{^Timeout=30$}}
+      it {should contain_file('/etc/zabbix/zabbix_agentd.conf').with_content %r{^UnsafeUserParameters=0$}}
+    end
   end
 end

--- a/spec/classes/database_mysql_spec.rb
+++ b/spec/classes/database_mysql_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+describe 'zabbix::database::mysql' do
+  let (:node) { 'rspec.puppet.com' }
+
+  context 'On RedHat 6.5' do
+    let (:facts) do
+      {
+        :osfamily                  => 'RedHat',
+        :operatingsystem           => 'RedHat',
+        :operatingsystemrelease    => '6.5',
+        :operatingsystemmajrelease => '6',
+        :architecture              => 'x86_64',
+        :lsbdistid                 => 'RedHat',
+        :concat_basedir            => '/tmp',
+      }
+    end
+
+    describe "when zabbix_type is server" do
+      let (:params) do
+        {
+          :database_name     => 'zabbix-server',
+          :database_user     => 'zabbix-server',
+          :database_password => 'zabbix-server',
+          :database_host     => 'node01.example.com',
+          :zabbix_type       => 'server',
+          :zabbix_version    => '2.4',
+        }
+      end
+
+      it { should contain_exec('zabbix_server_create.sql').with_command("cd /usr/share/doc/zabbix-*-mysql-2.4*/create && if [ -f schema.sql.gz ]; then gunzip schema.sql.gz ; fi && mysql -h 'node01.example.com' -u 'zabbix-server' -p'zabbix-server' -D 'zabbix-server' < schema.sql && touch /etc/zabbix/.schema.done") }
+      it { should contain_exec('zabbix_server_images.sql').with_command("cd /usr/share/doc/zabbix-*-mysql-2.4*/create && if [ -f images.sql.gz ]; then gunzip images.sql.gz ; fi && mysql -h 'node01.example.com' -u 'zabbix-server' -p'zabbix-server' -D 'zabbix-server' < images.sql && touch /etc/zabbix/.images.done") }
+      it { should contain_exec('zabbix_server_data.sql').with_command("cd /usr/share/doc/zabbix-*-mysql-2.4*/create && if [ -f data.sql.gz ]; then gunzip data.sql.gz ; fi && mysql -h 'node01.example.com' -u 'zabbix-server' -p'zabbix-server' -D 'zabbix-server' < data.sql && touch /etc/zabbix/.data.done") }
+    end
+
+    describe "when zabbix_type is proxy" do
+      let (:params) do
+        {
+          :database_name     => 'zabbix-proxy',
+          :database_user     => 'zabbix-proxy',
+          :database_password => 'zabbix-proxy',
+          :database_host     => 'node01.example.com',
+          :zabbix_type       => 'proxy',
+          :zabbix_version    => '2.4',
+        }
+      end
+
+      it { should contain_exec('zabbix_proxy_create.sql').with_command("cd /usr/share/doc/zabbix-*-mysql-2.4*/create && if [ -f schema.sql.gz ]; then gunzip schema.sql.gz ; fi && mysql -h 'node01.example.com' -u 'zabbix-proxy' -p'zabbix-proxy' -D 'zabbix-proxy' < schema.sql && touch /etc/zabbix/.schema.done") }
+    end
+  end
+end

--- a/spec/classes/database_postgresql_spec.rb
+++ b/spec/classes/database_postgresql_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+describe 'zabbix::database::postgresql' do
+  let (:node) { 'rspec.puppet.com' }
+
+  let (:pre_condition) do
+    "include ::postgresql::server"
+  end
+
+  context 'On RedHat 6.5' do
+    let (:facts) do
+      {
+        :osfamily                  => 'RedHat',
+        :operatingsystem           => 'RedHat',
+        :operatingsystemrelease    => '6.5',
+        :operatingsystemmajrelease => '6',
+        :architecture              => 'x86_64',
+        :lsbdistid                 => 'RedHat',
+        :concat_basedir            => '/tmp',
+      }
+    end
+
+    describe "when zabbix_type is server" do
+      let (:params) do
+        {
+          :database_name     => 'zabbix-server',
+          :database_user     => 'zabbix-server',
+          :database_password => 'zabbix-server',
+          :database_host     => 'node01.example.com',
+          :zabbix_type       => 'server',
+          :zabbix_version    => '2.4',
+        }
+      end
+
+      it { should contain_exec('update_pgpass').with_command('echo node01.example.com:5432:zabbix-server:zabbix-server:zabbix-server >> /root/.pgpass') }
+      it { should contain_exec('zabbix_server_create.sql').with_command("cd /usr/share/doc/zabbix-*-pgsql-2.4*/create && if [ -f schema.sql.gz ]; then gunzip schema.sql.gz ; fi && psql -h 'node01.example.com' -U 'zabbix-server' -d 'zabbix-server' -f schema.sql && touch /etc/zabbix/.schema.done") }
+      it { should contain_exec('zabbix_server_images.sql').with_command("cd /usr/share/doc/zabbix-*-pgsql-2.4*/create && if [ -f images.sql.gz ]; then gunzip images.sql.gz ; fi && psql -h 'node01.example.com' -U 'zabbix-server' -d 'zabbix-server' -f images.sql && touch /etc/zabbix/.images.done") }
+      it { should contain_exec('zabbix_server_data.sql').with_command("cd /usr/share/doc/zabbix-*-pgsql-2.4*/create && if [ -f data.sql.gz ]; then gunzip data.sql.gz ; fi && psql -h 'node01.example.com' -U 'zabbix-server' -d 'zabbix-server' -f data.sql && touch /etc/zabbix/.data.done") }
+    end
+
+    describe "when zabbix_type is proxy" do
+      let (:params) do
+        {
+          :database_name     => 'zabbix-proxy',
+          :database_user     => 'zabbix-proxy',
+          :database_password => 'zabbix-proxy',
+          :database_host     => 'node01.example.com',
+          :zabbix_type       => 'proxy',
+          :zabbix_version    => '2.4',
+        }
+      end
+
+      it { should contain_exec('update_pgpass').with_command('echo node01.example.com:5432:zabbix-proxy:zabbix-proxy:zabbix-proxy >> /root/.pgpass') }
+      it { should contain_exec('zabbix_proxy_create.sql').with_command("cd /usr/share/doc/zabbix-*-pgsql-2.4*/create && if [ -f schema.sql.gz ]; then gunzip schema.sql.gz ; fi && psql -h 'node01.example.com' -U 'zabbix-proxy' -d 'zabbix-proxy' -f schema.sql && touch /etc/zabbix/.schema.done") }
+    end
+  end
+end

--- a/spec/classes/database_spec.rb
+++ b/spec/classes/database_spec.rb
@@ -1,14 +1,16 @@
 require 'spec_helper'
 
 describe 'zabbix::database' do
-  # Set some facts / params.
-  let(:node) { 'rspec.puppet.com' }
+  let (:node) { 'rspec.puppet.com' }
 
-  # Running an RedHat OS.
-  context 'On a RedHat OS' do
-    let :facts do
+  let (:pre_condition) do
+    "class {'postgresql::server':}"
+  end
+
+  context 'On RedHat 6.5' do
+    let (:facts) do
       {
-	:kernel                    => 'Linux',
+        :kernel                    => 'Linux',
         :osfamily                  => 'RedHat',
         :operatingsystem           => 'RedHat',
         :operatingsystemrelease    => '6.5',
@@ -16,12 +18,13 @@ describe 'zabbix::database' do
         :architecture              => 'x86_64',
         :lsbdistid                 => 'RedHat',
         :concat_basedir            => '/tmp',
-	:puppetversion             => '4.0.0',
+        :puppetversion             => '4.0.0',
+        :id                        => 'root',
       }
     end
 
     describe "database_type is postgresql, zabbix_type is server and is multiple host setup" do
-      let :params do
+      let (:params) do
         {
           :database_type    => 'postgresql',
           :database_name    => 'zabbix-server',
@@ -31,6 +34,7 @@ describe 'zabbix::database' do
           :zabbix_server_ip => '127.0.0.1',
         }
       end
+
       it { should contain_postgresql__server__db('zabbix-server').with_name('zabbix-server') }
       it { should contain_postgresql__server__db('zabbix-server').with_user('zabbix-server') }
       
@@ -44,16 +48,17 @@ describe 'zabbix::database' do
     end
 
     describe "database_type is postgresql, zabbix_type is server and is single node setup" do
-      let :params do
+      let (:params) do
         {
           :database_type    => 'postgresql',
           :database_name    => 'zabbix-server',
           :database_user    => 'zabbix-server',
           :zabbix_type      => 'server',
           :zabbix_web_ip    => '127.0.0.1',
-          :zabbix_server_ip => '127.0.0.1'
+          :zabbix_server_ip => '127.0.0.1',
         }
       end
+
       it { should contain_postgresql__server__db('zabbix-server').with_name('zabbix-server') }
       it { should contain_postgresql__server__db('zabbix-server').with_user('zabbix-server') }
       
@@ -67,31 +72,33 @@ describe 'zabbix::database' do
     end
 
     describe "database_type is postgresql, zabbix_type is proxy" do
-      let :params do
+      let (:params) do
         {
           :database_type   => 'postgresql',
           :database_name   => 'zabbix-proxy',
           :database_user   => 'zabbix-proxy',
           :zabbix_type     => 'proxy',
-          :zabbix_proxy_ip => '127.0.0.1'
+          :zabbix_proxy_ip => '127.0.0.1',
         }
       end
+
       it { should contain_postgresql__server__pg_hba_rule('Allow zabbix-proxy to access database').with_database('zabbix-proxy') }
       it { should contain_postgresql__server__pg_hba_rule('Allow zabbix-proxy to access database').with_user('zabbix-proxy') }
       it { should contain_postgresql__server__pg_hba_rule('Allow zabbix-proxy to access database').with_address('127.0.0.1/32') }
     end
 
     describe "database_type is mysql, zabbix_type is server and is multiple host setup" do
-      let :params do
+      let (:params) do
         {
           :database_type    => 'mysql',
           :database_name    => 'zabbix-server',
           :database_user    => 'zabbix-server',
           :zabbix_type      => 'server',
           :zabbix_web       => 'node1.example.com',
-          :zabbix_server    => 'node0.example.com'
+          :zabbix_server    => 'node0.example.com',
         }
       end
+
       it { should contain_mysql__db('zabbix-server').with_name('zabbix-server') }
       it { should contain_mysql__db('zabbix-server').with_user('zabbix-server') }
       it { should contain_mysql__db('zabbix-server').with_host('node0.example.com') }
@@ -102,17 +109,18 @@ describe 'zabbix::database' do
       it { should contain_mysql_grant('zabbix-server@node1.example.com/zabbix-server.*').with_user('zabbix-server@node1.example.com') }
     end
 
-    describe "database_type is mysql, zabbix_type is server and is multiple host setup" do
-      let :params do
+    describe "database_type is mysql, zabbix_type is server and is a single host setup" do
+      let (:params) do
         {
           :database_type    => 'mysql',
           :database_name    => 'zabbix-server',
           :database_user    => 'zabbix-server',
           :zabbix_type      => 'server',
           :zabbix_web       => 'node0.example.com',
-          :zabbix_server    => 'node0.example.com'
+          :zabbix_server    => 'node0.example.com',
         }
       end
+
       it { should contain_mysql__db('zabbix-server').with_name('zabbix-server') }
       it { should contain_mysql__db('zabbix-server').with_user('zabbix-server') }
       it { should contain_mysql__db('zabbix-server').with_host('node0.example.com') }
@@ -123,133 +131,33 @@ describe 'zabbix::database' do
       it { should_not contain_mysql_grant('zabbix-server@node1.example.com/zabbix-server.*').with_user('zabbix-server@node1.example.com') }
     end
 
-    describe "database_type is mysql, zabbix_type is proxy" do
-      let :params do
+    describe "database_type is mysql, zabbix_type is proxy and is a single host setup" do
+      let (:params) do
         {
           :database_type => 'mysql',
           :database_name => 'zabbix-proxy',
           :database_user => 'zabbix-proxy',
           :zabbix_type   => 'proxy',
-          :zabbix_proxy  => 'node0.example.com'
+          :zabbix_proxy  => 'node0.example.com',
         }
       end
+
       it { should contain_mysql__db('zabbix-proxy').with_name('zabbix-proxy') }
     end
 
-    describe "database_type is mysql, zabbix_type is proxy" do
-      let :params do
+    describe "database_type is sqlite, zabbix_type is proxy and is a multiple host setup" do
+      let (:params) do
         {
           :database_type    => 'sqlite',
           :database_name    => 'zabbix-server',
           :database_user    => 'zabbix-server',
           :zabbix_type      => 'proxy',
-          :zabbix_web       => 'node1.example.com',
-          :zabbix_server    => 'node0.example.com'
+          :zabbix_web       => 'node0.example.com',
+          :zabbix_server    => 'node1.example.com',
         }
       end
+
       it { should contain_class('zabbix::database::sqlite') }
-    end
-  end
-end
-
-describe 'zabbix::database::postgresql' do
-  # Set some facts / params.
-  let(:node) { 'rspec.puppet.com' }
-
-  # Running an RedHat OS.
-  context 'On a RedHat OS' do
-    let :facts do
-      {
-        :osfamily                  => 'RedHat',
-        :operatingsystem           => 'RedHat',
-        :operatingsystemrelease    => '6.5',
-        :operatingsystemmajrelease => '6',
-        :architecture              => 'x86_64',
-        :lsbdistid                 => 'RedHat',
-        :concat_basedir            => '/tmp'
-      }
-    end
-
-    describe "when zabbix_type is server" do
-      let :params do
-        {
-          :database_name     => 'zabbix-server',
-          :database_user     => 'zabbix-server',
-          :database_password => 'zabbix-server',
-          :database_host     => 'node01.example.com',
-          :zabbix_type       => 'server',
-          :zabbix_version    => '2.4'
-        }
-      end
-      it { should contain_exec('update_pgpass').with_command('echo node01.example.com:5432:zabbix-server:zabbix-server:zabbix-server >> /root/.pgpass') }
-      it { should contain_exec('zabbix_server_create.sql').with_command("cd /usr/share/doc/zabbix-*-pgsql-2.4*/create && if [ -f schema.sql.gz ]; then gunzip schema.sql.gz ; fi && psql -h 'node01.example.com' -U 'zabbix-server' -d 'zabbix-server' -f schema.sql && touch /etc/zabbix/.schema.done") }
-      it { should contain_exec('zabbix_server_images.sql').with_command("cd /usr/share/doc/zabbix-*-pgsql-2.4*/create && if [ -f images.sql.gz ]; then gunzip images.sql.gz ; fi && psql -h 'node01.example.com' -U 'zabbix-server' -d 'zabbix-server' -f images.sql && touch /etc/zabbix/.images.done") }
-      it { should contain_exec('zabbix_server_data.sql').with_command("cd /usr/share/doc/zabbix-*-pgsql-2.4*/create && if [ -f data.sql.gz ]; then gunzip data.sql.gz ; fi && psql -h 'node01.example.com' -U 'zabbix-server' -d 'zabbix-server' -f data.sql && touch /etc/zabbix/.data.done") }
-    end
-
-    describe "when zabbix_type is proxy" do
-      let :params do
-        {
-          :database_name     => 'zabbix-proxy',
-          :database_user     => 'zabbix-proxy',
-          :database_password => 'zabbix-proxy',
-          :database_host     => 'node01.example.com',
-          :zabbix_type       => 'proxy',
-          :zabbix_version    => '2.4'
-        }
-      end
-      it { should contain_exec('update_pgpass').with_command('echo node01.example.com:5432:zabbix-proxy:zabbix-proxy:zabbix-proxy >> /root/.pgpass') }
-      it { should contain_exec('zabbix_proxy_create.sql').with_command("cd /usr/share/doc/zabbix-*-pgsql-2.4*/create && if [ -f schema.sql.gz ]; then gunzip schema.sql.gz ; fi && psql -h 'node01.example.com' -U 'zabbix-proxy' -d 'zabbix-proxy' -f schema.sql && touch /etc/zabbix/.schema.done") }
-    end
-  end
-end
-
-describe 'zabbix::database::mysql' do
-  # Set some facts / params.
-  let(:node) { 'rspec.puppet.com' }
-
-  # Running an RedHat OS.
-  context 'On a RedHat OS' do
-    let :facts do
-      {
-        :osfamily                  => 'RedHat',
-        :operatingsystem           => 'RedHat',
-        :operatingsystemrelease    => '6.5',
-        :operatingsystemmajrelease => '6',
-        :architecture              => 'x86_64',
-        :lsbdistid                 => 'RedHat',
-        :concat_basedir            => '/tmp'
-      }
-    end
-
-    describe "when zabbix_type is server" do
-      let :params do
-        {
-          :database_name     => 'zabbix-server',
-          :database_user     => 'zabbix-server',
-          :database_password => 'zabbix-server',
-          :database_host     => 'node01.example.com',
-          :zabbix_type       => 'server',
-          :zabbix_version    => '2.4'
-        }
-      end
-      it { should contain_exec('zabbix_server_create.sql').with_command("cd /usr/share/doc/zabbix-*-mysql-2.4*/create && if [ -f schema.sql.gz ]; then gunzip schema.sql.gz ; fi && mysql -h 'node01.example.com' -u 'zabbix-server' -p'zabbix-server' -D 'zabbix-server' < schema.sql && touch /etc/zabbix/.schema.done") }
-      it { should contain_exec('zabbix_server_images.sql').with_command("cd /usr/share/doc/zabbix-*-mysql-2.4*/create && if [ -f images.sql.gz ]; then gunzip images.sql.gz ; fi && mysql -h 'node01.example.com' -u 'zabbix-server' -p'zabbix-server' -D 'zabbix-server' < images.sql && touch /etc/zabbix/.images.done") }
-      it { should contain_exec('zabbix_server_data.sql').with_command("cd /usr/share/doc/zabbix-*-mysql-2.4*/create && if [ -f data.sql.gz ]; then gunzip data.sql.gz ; fi && mysql -h 'node01.example.com' -u 'zabbix-server' -p'zabbix-server' -D 'zabbix-server' < data.sql && touch /etc/zabbix/.data.done") }
-    end
-
-    describe "when zabbix_type is proxy" do
-      let :params do
-        {
-          :database_name     => 'zabbix-proxy',
-          :database_user     => 'zabbix-proxy',
-          :database_password => 'zabbix-proxy',
-          :database_host     => 'node01.example.com',
-          :zabbix_type       => 'proxy',
-          :zabbix_version    => '2.4'
-        }
-      end
-      it { should contain_exec('zabbix_proxy_create.sql').with_command("cd /usr/share/doc/zabbix-*-mysql-2.4*/create && if [ -f schema.sql.gz ]; then gunzip schema.sql.gz ; fi && mysql -h 'node01.example.com' -u 'zabbix-proxy' -p'zabbix-proxy' -D 'zabbix-proxy' < schema.sql && touch /etc/zabbix/.schema.done") }
     end
   end
 end

--- a/spec/classes/javagateway_spec.rb
+++ b/spec/classes/javagateway_spec.rb
@@ -1,57 +1,66 @@
 require 'spec_helper'
 
 describe 'zabbix::javagateway' do
-  # Set some facts / params.
-  let(:node) { 'rspec.puppet.com' }
+  let (:node) { 'rspec.puppet.com' }
 
-  # Running an RedHat OS.
-  context 'On a RedHat OS' do
-    let :facts do
+  context 'On RedHat 6.5' do
+    let (:facts) do
       {
         :osfamily               => 'RedHat',
         :operatingsystem        => 'RedHat',
         :operatingsystemrelease => '6.5',
         :architecture           => 'x86_64',
         :lsbdistid              => 'RedHat',
-        :concat_basedir         => '/tmp'
+        :concat_basedir         => '/tmp',
       }
-    end
-
-    context 'when declaring manage_repo is true' do
-      let(:params) {{ :manage_repo => true }}
-      it { should contain_class('Zabbix::Repo') }
     end
 
     it { should contain_file('/etc/zabbix/zabbix_java_gateway.conf')}
     it { should contain_service('zabbix-java-gateway')}
 
+    context 'when declaring manage_repo is true' do
+      let (:params) do
+        {
+          :manage_repo => true,
+        }
+      end
+
+      it { should contain_class('Zabbix::Repo') }
+    end
+
     context "when declaring manage_firewall is true" do
-      let(:params) {{ :manage_firewall => true }}
+      let(:params) do
+        {
+          :manage_firewall => true,
+        }
+      end
+
       it { should contain_firewall('152 zabbix-javagateway') }
     end
   
     context "when declaring manage_firewall is false" do
-      let(:params) {{ :manage_firewall => false }}
+      let(:params) do
+        {
+          :manage_firewall => false,
+        }
+      end
+
       it { should_not contain_firewall('152 zabbix-javagateway') }
     end 
 
-    context 'with listenip => 192.168.1.1' do
-      let(:params) { { :listenip => '192.168.1.1' } }
+    context 'with zabbix_java_gateway.conf settings' do
+      let(:params) do
+        {
+          :listenip => '192.168.1.1',
+          :listenport => '10052',
+          :pidfile => '/var/run/zabbix/zabbix_java.pid',
+          :startpollers => '5',
+        }
+      end
+
       it { should contain_file('/etc/zabbix/zabbix_java_gateway.conf').with_content %r{^LISTEN_IP=192.168.1.1$} }
-    end
-
-    context 'with listenport => 10052' do
-      let(:params) { { :listenport => '10052' } }
       it { should contain_file('/etc/zabbix/zabbix_java_gateway.conf').with_content %r{^LISTEN_PORT=10052$} }
-    end
-
-    context 'with pidfile => /var/run/zabbix/zabbix_java.pid' do
-      let(:params) { { :pidfile => '/var/run/zabbix/zabbix_java.pid' } }
       it { should contain_file('/etc/zabbix/zabbix_java_gateway.conf').with_content %r{^PID_FILE=/var/run/zabbix/zabbix_java.pid$} }
-    end
-
-    context 'with startpollers => 5' do
-      let(:params) { { :startpollers => '5' } }
       it { should contain_file('/etc/zabbix/zabbix_java_gateway.conf').with_content %r{^START_POLLERS=5$} }
     end
   end

--- a/spec/classes/proxy_spec.rb
+++ b/spec/classes/proxy_spec.rb
@@ -1,63 +1,92 @@
 require 'spec_helper'
 
 describe 'zabbix::proxy' do
-  # Set some facts / params.
-  let(:params) { {:zabbix_server_host => '192.168.1.1', :zabbix_version => '2.4'} }
-  let(:node) { 'rspec.puppet.com' }
+  let (:node) { 'rspec.puppet.com' }
 
-  context 'On a RedHat OS' do
-    # Set some facts first.
-    let :facts do
+  let (:params) do
+    {
+      :zabbix_server_host => '192.168.1.1',
+      :zabbix_version => '2.4'
+    }
+  end
+
+  context 'On RedHat 6.5' do
+    let (:facts) do
       {
-        :osfamily               => 'RedHat',
-        :operatingsystem        => 'RedHat',
-        :operatingsystemrelease => '6.5',
-        :architecture           => 'x86_64',
-        :lsbdistid              => 'RedHat',
-        :concat_basedir         => '/tmp'
+        :osfamily                  => 'RedHat',
+        :operatingsystem           => 'RedHat',
+        :operatingsystemrelease    => '6.5',
+        :operatingsystemmajrelease => '6',
+        :architecture              => 'x86_64',
+        :lsbdistid                 => 'RedHat',
+        :concat_basedir            => '/tmp',
       }
     end
-
-    describe "when manage_repo is true" do
-        let(:params) {{ :manage_repo => true }}
-        it { should contain_class('zabbix::repo').with_zabbix_version('2.4') }
-        it { should contain_package('zabbix-proxy-pgsql').with_require('Class[Zabbix::Repo]') }
-    end
-
-    describe "when databaste_type is postgresql" do
-        let(:params) {{ :database_type => 'postgresql' }}
-        it { should contain_package('zabbix-proxy-pgsql').with_ensure('present') }
-        it { should contain_package('zabbix-proxy-pgsql').with_ensure('present') }
-        it { should contain_package('zabbix-proxy-pgsql').with_name('zabbix-proxy-pgsql') }
-        it { should contain_service('zabbix-proxy').with_require(['Package[zabbix-proxy-pgsql]','File[/etc/zabbix/zabbix_proxy.conf.d]','File[/etc/zabbix/zabbix_proxy.conf]']) }
-        it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_require('Package[zabbix-proxy-pgsql]') }
-    end
-
-    describe "when databaste_type is mysql" do
-        let(:params) {{ :database_type => 'mysql' }}
-        it { should contain_package('zabbix-proxy-mysql').with_ensure('present') }
-        it { should contain_package('zabbix-proxy-mysql').with_ensure('present') }
-        it { should contain_package('zabbix-proxy-mysql').with_name('zabbix-proxy-mysql') }
-        it { should contain_service('zabbix-proxy').with_require(['Package[zabbix-proxy-mysql]','File[/etc/zabbix/zabbix_proxy.conf.d]','File[/etc/zabbix/zabbix_proxy.conf]']) }
-        it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_require('Package[zabbix-proxy-mysql]') }
-    end
-
-    describe "when databaste_type is mysql" do
-        let(:params) {{ :manage_resources => true }}
-        it { should contain_class('zabbix::resources::proxy') }
-    end
-
-    describe "whem manage_repo is true" do
-        let(:params) {{ :manage_repo => true }}
-        it { should contain_class('Zabbix::Repo') }
+  
+    let (:pre_condition) do
+      "class {'postgresql::server':}"
     end
 
     it { should contain_file('/etc/zabbix/zabbix_proxy.conf.d').with_ensure('directory') }
     it { should contain_file('/etc/zabbix/zabbix_proxy.conf.d').with_require('File[/etc/zabbix/zabbix_proxy.conf]') }
   
-  
+    describe "when manage_repo is true" do
+      let (:params) do
+        {
+          :manage_repo => true,
+        }
+      end
+
+      it { should contain_class('zabbix::repo').with_zabbix_version('2.4') }
+      it { should contain_package('zabbix-proxy-pgsql').with_require('Class[Zabbix::Repo]') }
+    end
+
+    describe "when database_type is postgresql" do
+      let (:params) do
+        {
+          :database_type => 'postgresql',
+        }
+      end
+
+      it { should contain_package('zabbix-proxy-pgsql').with_ensure('present') }
+      it { should contain_package('zabbix-proxy-pgsql').with_ensure('present') }
+      it { should contain_package('zabbix-proxy-pgsql').with_name('zabbix-proxy-pgsql') }
+      it { should contain_service('zabbix-proxy').with_require(['Package[zabbix-proxy-pgsql]','File[/etc/zabbix/zabbix_proxy.conf.d]','File[/etc/zabbix/zabbix_proxy.conf]']) }
+      it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_require('Package[zabbix-proxy-pgsql]') }
+    end
+
+    describe "when database_type is mysql" do
+      let (:params) do
+        {
+          :database_type => 'mysql',
+        }
+      end
+
+      it { should contain_package('zabbix-proxy-mysql').with_ensure('present') }
+      it { should contain_package('zabbix-proxy-mysql').with_ensure('present') }
+      it { should contain_package('zabbix-proxy-mysql').with_name('zabbix-proxy-mysql') }
+      it { should contain_service('zabbix-proxy').with_require(['Package[zabbix-proxy-mysql]','File[/etc/zabbix/zabbix_proxy.conf.d]','File[/etc/zabbix/zabbix_proxy.conf]']) }
+      it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_require('Package[zabbix-proxy-mysql]') }
+    end
+
+    describe "when manage_resources is true" do
+      let (:params) do
+        {
+          :manage_resources => true,
+        }
+      end
+
+      it { should contain_class('zabbix::resources::proxy') }
+    end
+
     context 'with zabbix::database::postgresql class' do
-      let(:params) {{ :database_type => 'postgresql', :manage_database => true }}
+      let (:params) do
+        {
+          :database_type => 'postgresql',
+          :manage_database => true,
+        }
+      end
+
       it { should contain_class('zabbix::database::postgresql').with_zabbix_type('proxy')}
       it { should contain_class('zabbix::database::postgresql').with_zabbix_version('2.4')}
       it { should contain_class('zabbix::database::postgresql').with_database_name('zabbix_proxy')}
@@ -66,9 +95,18 @@ describe 'zabbix::proxy' do
       it { should contain_class('zabbix::database::postgresql').with_database_host('localhost')}
     end
 
-  
     context 'with zabbix::database::mysql class' do
-      let(:params) {{ :database_type => 'mysql', :manage_database => true }}
+      let(:params) do
+        {
+          :database_type => 'mysql',
+          :manage_database => true,
+        }
+      end
+
+      let(:pre_condition) do
+        "include 'mysql::server'"
+      end
+
       it { should contain_class('zabbix::database::mysql').with_zabbix_type('proxy')}
       it { should contain_class('zabbix::database::mysql').with_zabbix_version('2.4')}
       it { should contain_class('zabbix::database::mysql').with_database_name('zabbix_proxy')}
@@ -78,7 +116,12 @@ describe 'zabbix::proxy' do
     end
 
     context 'when manage_database is true' do
-      let(:params) {{ :manage_database => true }}
+      let(:params) do
+        {
+          :manage_database => true,
+        }
+      end
+
       it { should contain_class('zabbix::database').with_zabbix_type('proxy')}
       it { should contain_class('zabbix::database').with_database_type('postgresql')}
       it { should contain_class('zabbix::database').with_database_name('zabbix_proxy')}
@@ -90,300 +133,144 @@ describe 'zabbix::proxy' do
     end
 
     context "when declaring manage_firewall is true" do
-      let(:params) {{ :manage_firewall => true }}
+      let(:params) do
+        {
+          :manage_firewall => true,
+        }
+      end
+
       it { should contain_firewall('151 zabbix-proxy') }
     end
 
     context "when declaring manage_firewall is false" do
-      let(:params) {{ :manage_firewall => false }}
+      let(:params) do
+        {
+          :manage_firewall => false,
+        }
+      end
+
       it { should_not contain_firewall('151 zabbix-proxy') }
     end
 
 
-  # Make sure we have set some vars in zabbix_proxy.conf file. This is configuration file is the same on all
-  # operating systems. So we aren't testing this for all opeating systems, just this one.
+    # Make sure we have set some vars in zabbix_proxy.conf file. This is configuration file is the same on all
+    # operating systems. So we aren't testing this for all opeating systems, just this one.
+    context 'with zabbix_proxy.conf settings' do
+      let(:params) do
+        {
+          :allowroot               => '0',
+          :cachesize               => '8M',
+          :configfrequency         => '3600',
+          :database_host           => 'localhost',
+          :database_name           => 'zabbix-proxy',
+          :database_password       => 'zabbix-proxy',
+          :database_schema         => 'zabbix-proxy',
+          :database_user           => 'zabbix-proxy',
+          :datasenderfrequency     => '1',
+          :debuglevel              => '4',
+          :externalscripts         => '/usr/lib/zabbix/externalscripts',
+          :fping6location          => '/usr/sbin/fping6',
+          :fpinglocation           => '60',
+          :heartbeatfrequency      => '60',
+          :historycachesize        => '16M',
+          :historytextcachesize    => '8M',
+          :hostname                => 'rspec.puppet.com',
+          :housekeepingfrequency   => '1',
+          :include_dir             => '/etc/zabbix/zabbix_proxy.conf.d',
+          :javagateway             => '192.168.1.2',
+          :javagatewayport         => '10051',
+          :startjavapollers        => '5',
+          :listenip                => '192.168.1.1',
+          :listenport              => '10051',
+          :loadmodulepath          => '${libdir}/modules',
+          :loadmodule              => 'pizza',
+          :localbuffer             => '0',
+          :logfilesize             => '15',
+          :logfile                 => '/var/log/zabbix/proxy_server.log',
+          :loglowqueries           => '0',
+          :mode                    => '0',
+          :offlinebuffer           => '1',
+          :pidfile                 => '/var/run/zabbix/proxy_server.pid',
+          :snmptrapper             => '0',
+          :snmptrapperfile         => '/tmp/zabbix_traps.tmp',
+          :sshkeylocation          => '/home/zabbix/.ssh/',
+          :startdbsyncers          => '4',
+          :startdiscoverers        => '15',
+          :starthttppollers        => '15',
+          :startipmipollers        => '15',
+          :startpingers            => '15',
+          :startpollers            => '15',
+          :startpollersunreachable => '15',
+          :starttrappers           => '15',
+          :startvmwarecollectors   => '0',
+          :timeout                 => '20',
+          :tmpdir                  => '/tmp',
+          :trappertimeout          => '16',
+          :unavaliabledelay        => '60',
+          :unreachabedelay         => '15',
+          :unreachableperiod       => '45',
+          :vmwarecachesize         => '8M',
+          :vmwarefrequency         => '60',
+          :zabbix_server_host      => '192.168.1.1',
+          :zabbix_server_port      => '10051',
+          :zabbix_version          => '2.2',
+        }
+      end
 
-    context 'with mode => 0' do
-      let(:params) { {:mode => '0'} }
       it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^ProxyMode=0$}}
-    end
-
-    context 'with zabbix_server_host => 192.168.1.1' do
-      let(:params) { {:zabbix_server_host => '192.168.1.1'} }
       it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^Server=192.168.1.1$}}
-    end
-
-    context 'with zabbix_server_port => 10051' do
-      let(:params) { {:zabbix_server_port => '10051'} }
       it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^ServerPort=10051$}}
-    end
-
-    context 'with zabbix_server_port => 10051' do
-      let(:params) { {:zabbix_server_port => '10051'} }
-      it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^ServerPort=10051$}}
-    end
-
-    context 'with Hostname => rspec.puppet.com' do
       it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^Hostname=rspec.puppet.com$}}
-    end
-
-    context 'with listenport => 10051' do
-      let(:params) { {:listenport => '10051'} }
       it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^ListenPort=10051$}}
-    end 
-
-    context 'with logfile => /var/log/zabbix/proxy_server.log' do
-      let(:params) { {:logfile => '/var/log/zabbix/proxy_server.log'} }
       it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^LogFile=/var/log/zabbix/proxy_server.log$}}
-    end 
-
-    context 'with logfilesize => 15' do
-      let(:params) { {:logfilesize => '15'} }
       it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^LogFileSize=15$}}
-    end   
-
-    context 'with debuglevel => 4' do
-      let(:params) { {:debuglevel => '4'} }
       it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^DebugLevel=4$}}
-    end   
-
-    context 'with pidfile => /var/run/zabbix/proxy_server.pid' do
-      let(:params) { {:pidfile => '/var/run/zabbix/proxy_server.pid'} }
       it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^PidFile=/var/run/zabbix/proxy_server.pid$}}
-    end   
-
-    context 'with database_host => localhost' do
-      let(:params) { {:database_host => 'localhost'} }
       it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^DBHost=localhost$}}
-    end   
-
-    context 'with database_name => zabbix-proxy' do
-      let(:params) { {:database_name => 'zabbix-proxy'} }
       it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^DBName=zabbix-proxy$}}
-    end   
-
-    context 'with database_schema => zabbix-proxy' do
-      let(:params) { {:database_schema => 'zabbix-proxy'} }
       it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^DBSchema=zabbix-proxy$}}
-    end   
-
-    context 'with database_user => zabbix-proxy' do
-      let(:params) { {:database_user => 'zabbix-proxy'} }
       it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^DBUser=zabbix-proxy$}}
-    end   
-
-    context 'with database_password => zabbix-proxy' do
-      let(:params) { {:database_password => 'zabbix-proxy'} }
       it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^DBPassword=zabbix-proxy$}}
-    end   
-
-    context 'with localbuffer => 0' do
-      let(:params) { {:localbuffer => '0'} }
       it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^ProxyLocalBuffer=0$}}
-    end   
-
-    context 'with offlinebuffer => 1' do
-      let(:params) { {:offlinebuffer => '1'} }
       it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^ProxyOfflineBuffer=1$}}
-    end   
-
-    context 'with heartbeatfrequency => 60' do
-      let(:params) { {:heartbeatfrequency => '60'} }
       it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^HeartbeatFrequency=60$}}
-    end   
-
-    context 'with configfrequency => 3600' do
-      let(:params) { {:configfrequency => '3600'} }
       it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^ConfigFrequency=3600$}}
-    end   
-
-    context 'with datasenderfrequency => 1' do
-      let(:params) { {:datasenderfrequency => '1'} }
       it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^DataSenderFrequency=1$}}
-    end   
-
-    context 'with startpollers => 15' do
-      let(:params) { {:startpollers => '15'} }
       it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^StartPollers=15$}}
-    end   
-
-    context 'with startipmipollers => 15' do
-      let(:params) { {:startipmipollers => '15'} }
       it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^StartIPMIPollers=15$}}
-    end   
-
-    context 'with startpollersunreachable => 15' do
-      let(:params) { {:startpollersunreachable => '15'} }
       it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^StartPollersUnreachable=15$}}
-    end   
-
-    context 'with starttrappers => 15' do
-      let(:params) { {:starttrappers => '15'} }
       it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^StartTrappers=15$}}
-    end   
-
-    context 'with startpingers => 15' do
-      let(:params) { {:startpingers => '15'} }
       it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^StartPingers=15$}}
-    end   
-
-    context 'with startdiscoverers => 15' do
-      let(:params) { {:startdiscoverers => '15'} }
       it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^StartDiscoverers=15$}}
-    end   
-
-    context 'with starthttppollers => 15' do
-      let(:params) { {:starthttppollers => '15'} }
       it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^StartHTTPPollers=15$}}
-    end   
-
-    context 'with javagateway => 192.168.1.2' do
-      let(:params) { {:javagateway => '192.168.1.2'} }
       it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^JavaGateway=192.168.1.2$}}
-    end   
-
-    context 'with javagatewayport => 10051' do
-      let(:params) { {:javagateway => '192.168.1.2', :javagatewayport => '10051'} }
       it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^JavaGatewayPort=10051$}}
-    end   
-
-    context 'with startjavapollers => 5' do
-      let(:params) { {:javagateway => '192.168.1.2', :startjavapollers => '5'} }
       it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^StartJavaPollers=5$}}
-    end   
-
-    context 'with startvmwarecollectors => 0' do
-      let(:params) { {:startvmwarecollectors => '0'} }
       it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^StartVMwareCollectors=0$}}
-    end   
-
-    context 'with vmwarefrequency => 60' do
-      let(:params) { {:vmwarefrequency => '60'} }
       it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^VMwareFrequency=60$}}
-    end   
-
-    context 'with vmwarecachesize => 8M' do
-      let(:params) { {:vmwarecachesize => '8M'} }
       it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^VMwareCacheSize=8M$}}
-    end 
-    
-    context 'with snmptrapperfile => 60' do
-      let(:params) { {:snmptrapperfile => '/tmp/zabbix_traps.tmp'} }
       it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^SNMPTrapperFile=/tmp/zabbix_traps.tmp$}}
-    end 
-    
-    context 'with snmptrapper => 0' do
-      let(:params) { {:snmptrapper => '0'} }
       it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^StartSNMPTrapper=0$}}
-    end 
-
-    context 'with listenip => 192.168.1.1' do
-      let(:params) { {:listenip => '192.168.1.1'} }
       it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^ListenIP=192.168.1.1$}}
-    end 
-        
-    context 'with housekeepingfrequency => 1' do
-      let(:params) { {:housekeepingfrequency => '1'} }
       it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^HousekeepingFrequency=1$}}
-    end 
-    
-    context 'with cachesize => 8M' do
-      let(:params) { {:cachesize => '8M'} }
       it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^CacheSize=8M$}}
-    end 
-    
-    context 'with startdbsyncers => 4' do
-      let(:params) { {:startdbsyncers => '4'} }
       it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^StartDBSyncers=4$}}
-    end 
-
-    context 'with historycachesize => 16M' do
-      let(:params) { {:historycachesize => '16M'} }
       it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^HistoryCacheSize=16M$}}
-    end   
-  
-    context 'with historytextcachesize => 8M' do
-      let(:params) { {:historytextcachesize => '8M'} }
       it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^HistoryTextCacheSize=8M$}}
-    end 
-    
-    context 'with timeout => 20' do
-      let(:params) { {:timeout => '20'} }
       it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^Timeout=20$}}
-    end 
-
-    context 'with trappertimeout => 16' do
-      let(:params) { {:trappertimeout => '16'} }
       it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^TrapperTimeout=16$}}
-    end   
-  
-    context 'with unreachableperiod => 45' do
-      let(:params) { {:unreachableperiod => '45'} }
       it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^UnreachablePeriod=45$}}
-    end 
-
-    context 'with unavaliabledelay => 60' do
-      let(:params) { {:unavaliabledelay => '60'} }
       it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^UnavailableDelay=60$}}
-    end    
-  
-    context 'with unreachabedelay => 15' do
-      let(:params) { {:unreachabedelay => '15'} }
       it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^UnreachableDelay=15$}}
-    end 
-
-    context 'with externalscripts => 60' do
-      let(:params) { {:externalscripts => '/usr/lib/zabbix/externalscripts'} }
       it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^ExternalScripts=/usr/lib/zabbix/externalscripts$}}
-    end  
-  
-    context 'with fpinglocation => 60' do
-      let(:params) { {:fpinglocation => '60'} }
       it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^FpingLocation=60$}}
-    end    
-  
-    context 'with unreachabedelay => /usr/sbin/fping' do
-      let(:params) { {:unreachabedelay => '/usr/sbin/fping'} }
-      it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^UnreachableDelay=/usr/sbin/fping$}}
-    end 
-
-    context 'with fping6location => /usr/sbin/fping6' do
-      let(:params) { {:fping6location => '/usr/sbin/fping6'} }
       it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^Fping6Location=/usr/sbin/fping6$}}
-    end  
-
-    context 'with sshkeylocation => /home/zabbix/.ssh/' do
-      let(:params) { {:sshkeylocation => '/home/zabbix/.ssh/'} }
       it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^SSHKeyLocation=/home/zabbix/.ssh/$}}
-    end   
-
-    context 'with loglowqueries => 0' do
-      let(:params) { {:loglowqueries => '0'} }
       it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^LogSlowQueries=0$}}
-    end 
-
-    context 'with tmpdir => /tmp' do
-      let(:params) { {:tmpdir => '/tmp'} }
       it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^TmpDir=/tmp$}}
-    end  
-
-    context 'with allowroot => 0' do
-      let(:params) { {:allowroot => '0',:zabbix_version => '2.2'} }
       it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^AllowRoot=0$}}
-    end  
-
-    context 'with include_dir => /etc/zabbix/zabbix_proxy.conf.d' do
-      let(:params) { {:include_dir => '/etc/zabbix/zabbix_proxy.conf.d'} }
       it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^Include=/etc/zabbix/zabbix_proxy.conf.d$}}
-    end
-    
-    context 'with loadmodulepath => ${libdir}/modules' do
-      let(:params) { {:loadmodulepath => '${libdir}/modules'} }
       it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^LoadModulePath=\$\{libdir\}/modules$}}
-    end  
-
-    context 'with loadmodule => pizza' do
-      let(:params) { {:loadmodule => 'pizza'} }
       it { should contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^LoadModule=pizza$}}
     end  
   end # END context 'zabbix_proxy.conf configuration'

--- a/spec/classes/repo_spec.rb
+++ b/spec/classes/repo_spec.rb
@@ -1,13 +1,15 @@
 require 'spec_helper'
 
 describe 'zabbix::repo' do
-  # Set some facts / params.
-#  let(:params) { {:manage_repo => true} }
+  context "on Debian 6 and Zabbix 2.0" do
+    let (:params) do
+      {
+        :zabbix_version => '2.0',
+        :manage_repo => true,
+      }
+    end
 
-  # Testing the Debian: 6, ZBX: 2.0
-  context "on a Debian OS" do
-    let(:params) { {:zabbix_version => '2.0', :manage_repo => true} }
-    let :facts do
+    let (:facts) do
       {
         :operatingsystem        => 'Debian',
         :operatingsystemrelease => '6',
@@ -17,13 +19,19 @@ describe 'zabbix::repo' do
         :osfamily               => 'Debian'
       }
     end
+
     it { should contain_apt__source('zabbix').with_location('http://repo.zabbix.com/zabbix/2.0/debian/') }
   end
 
-  # Testing the Debian: 7, ZBX: 2.0
-  context "on a Debian OS" do
-    let(:params) { {:zabbix_version => '2.0', :manage_repo => true} }
-    let :facts do
+  context "on Debian 7 and Zabbix 2.0" do
+    let (:params) do
+      {
+        :zabbix_version => '2.0',
+        :manage_repo => true,
+      }
+    end
+
+    let (:facts) do
       {
         :operatingsystem        => 'Debian',
         :operatingsystemrelease => '7',
@@ -33,13 +41,19 @@ describe 'zabbix::repo' do
         :osfamily               => 'Debian'
       }
     end
+
     it { should contain_apt__source('zabbix').with_location('http://repo.zabbix.com/zabbix/2.0/debian/') }
   end
 
-  # Testing the Debian: 7, ZBX: 2.2
-  context "on a Debian OS" do
-    let(:params) { {:zabbix_version => '2.2', :manage_repo => true} }
-    let :facts do
+  context "on Debian 7 and Zabbix 2.2" do
+    let (:params) do
+      {
+        :zabbix_version => '2.2',
+        :manage_repo => true,
+      }
+    end
+
+    let (:facts) do
       {
         :operatingsystem        => 'Debian',
         :operatingsystemrelease => '7',
@@ -49,13 +63,19 @@ describe 'zabbix::repo' do
         :osfamily               => 'Debian'
       }
     end
+
     it { should contain_apt__source('zabbix').with_location('http://repo.zabbix.com/zabbix/2.2/debian/') }
   end
 
-  # Testing the Debian: 7, ZBX: 2.4
-  context "on a Debian OS" do
-    let(:params) { {:zabbix_version => '2.4', :manage_repo => true} }
-    let :facts do
+  context "on Debian 7 and Zabbix 2.4" do
+    let (:params) do
+      {
+        :zabbix_version => '2.4',
+        :manage_repo => true,
+      }
+    end
+
+    let (:facts) do
       {
         :operatingsystem        => 'Debian',
         :operatingsystemrelease => '7',
@@ -65,13 +85,19 @@ describe 'zabbix::repo' do
         :osfamily               => 'Debian'
       }
     end
+
     it { should contain_apt__source('zabbix').with_location('http://repo.zabbix.com/zabbix/2.4/debian/') }
   end
 
-  # Testing the Ubuntu: 12.04, ZBX: 2.0
-  context "on a Ubuntu OS" do
-    let(:params) { {:zabbix_version => '2.0', :manage_repo => true} }
-    let :facts do
+  context "on Ubuntu 12.04 and Zabbix 2.0" do
+    let (:params) do
+      {
+        :zabbix_version => '2.0',
+        :manage_repo => true,
+      }
+    end
+
+    let (:facts) do
       {
         :operatingsystem        => 'Ubuntu',
         :operatingsystemrelease => '12.04',
@@ -81,13 +107,19 @@ describe 'zabbix::repo' do
         :osfamily               => 'Debian'
       }
     end
+
     it { should contain_apt__source('zabbix').with_location('http://repo.zabbix.com/zabbix/2.0/ubuntu/') }
   end
 
-  # Testing the Ubuntu: 12.04, ZBX: 2.2
-  context "on a Ubuntu OS" do
-    let(:params) { {:zabbix_version => '2.2', :manage_repo => true} }
-    let :facts do
+  context "on Ubuntu 12.04 and Zabbix 2.2" do
+    let (:params) do
+      {
+        :zabbix_version => '2.2',
+        :manage_repo => true,
+      }
+    end
+
+    let (:facts) do
       {
         :operatingsystem        => 'Ubuntu',
         :operatingsystemrelease => '12.04',
@@ -97,13 +129,19 @@ describe 'zabbix::repo' do
         :osfamily               => 'Debian'
       }
     end
+
     it { should contain_apt__source('zabbix').with_location('http://repo.zabbix.com/zabbix/2.2/ubuntu/') }
   end
 
-  # Testing the Ubuntu: 12.04, ZBX: 2.4
-  context "on a Ubuntu OS" do
-    let(:params) { {:zabbix_version => '2.4', :manage_repo => true} }
-    let :facts do
+  context "on Ubuntu 12.04 and Zabbix 2.4" do
+    let (:params) do
+      {
+        :zabbix_version => '2.4',
+        :manage_repo => true,
+      }
+    end
+
+    let (:facts) do
       {
         :operatingsystem        => 'Ubuntu',
         :operatingsystemrelease => '12.04',
@@ -113,14 +151,20 @@ describe 'zabbix::repo' do
         :osfamily               => 'Debian'
       }
     end
+
     it { should contain_apt__source('zabbix').with_location('http://repo.zabbix.com/zabbix/2.4/ubuntu/') }
   end
 
 
-  # Testing the RHEL: 5, ZBX: 2.0
-  context "on a RedHat OS" do
-    let(:params) { {:zabbix_version => '2.0', :manage_repo => true} }
-    let :facts do
+  context "on RedHat 5 and Zabbix 2.0" do
+    let (:params) do
+      {
+        :zabbix_version => '2.0',
+        :manage_repo => true,
+      }
+    end
+
+    let (:facts) do
       {
         :operatingsystem        => 'RedHat',
         :operatingsystemrelease => '5',
@@ -128,14 +172,20 @@ describe 'zabbix::repo' do
         :osfamily               => 'RedHat'
       }
     end
+
     it { should contain_yumrepo('zabbix').with_baseurl('http://repo.zabbix.com/zabbix/2.0/rhel/$releasever/$basearch/') }
     it { should contain_yumrepo('zabbix-nonsupported').with_baseurl('http://repo.zabbix.com/non-supported/rhel/$releasever/$basearch/') }
   end
 
-  # Testing the RHEL: 6, ZBX: 2.0
-  context "on a RedHat OS" do
-    let(:params) { {:zabbix_version => '2.0', :manage_repo => true} }
-    let :facts do
+  context "on RedHat 6 and Zabbix 2.0" do
+    let (:params) do
+      {
+        :zabbix_version => '2.0',
+        :manage_repo => true,
+      }
+    end
+
+    let (:facts) do
       {
         :operatingsystem        => 'RedHat',
         :operatingsystemrelease => '6',
@@ -144,14 +194,20 @@ describe 'zabbix::repo' do
         :$majorrelease          => '6'
       }
     end
+
     it { should contain_yumrepo('zabbix').with_baseurl('http://repo.zabbix.com/zabbix/2.0/rhel/$releasever/$basearch/') }
     it { should contain_yumrepo('zabbix-nonsupported').with_baseurl('http://repo.zabbix.com/non-supported/rhel/$releasever/$basearch/') }
   end
 
-  # Testing the RHEL: 6, ZBX: 2.2
-  context "on a RedHat OS" do
-    let(:params) { {:zabbix_version => '2.2', :manage_repo => true} }
-    let :facts do
+  context "on RedHat 6 and Zabbix 2.2" do
+    let (:params) do
+      {
+        :zabbix_version => '2.2',
+        :manage_repo => true,
+      }
+    end
+
+    let (:facts) do
       {
         :operatingsystem        => 'RedHat',
         :operatingsystemrelease => '6',
@@ -160,14 +216,20 @@ describe 'zabbix::repo' do
         :$majorrelease          => '6'
       }
     end
+
     it { should contain_yumrepo('zabbix').with_baseurl('http://repo.zabbix.com/zabbix/2.2/rhel/$releasever/$basearch/') }
     it { should contain_yumrepo('zabbix-nonsupported').with_baseurl('http://repo.zabbix.com/non-supported/rhel/$releasever/$basearch/') }
   end
 
-  # Testing the RHEL: 6, ZBX: 2.4
-  context "on a RedHat OS" do
-    let(:params) { {:zabbix_version => '2.4', :manage_repo => true} }
-    let :facts do
+  context "on RedHat 6 and Zabbix 2.4" do
+    let (:params) do
+      {
+        :zabbix_version => '2.4',
+        :manage_repo => true,
+      }
+    end
+
+    let (:facts) do
       {
         :operatingsystem        => 'RedHat',
         :operatingsystemrelease => '6',
@@ -176,6 +238,7 @@ describe 'zabbix::repo' do
         :$majorrelease          => '6'
       }
     end
+
     it { should contain_yumrepo('zabbix').with_baseurl('http://repo.zabbix.com/zabbix/2.4/rhel/$releasever/$basearch/') }
     it { should contain_yumrepo('zabbix-nonsupported').with_baseurl('http://repo.zabbix.com/non-supported/rhel/$releasever/$basearch/') }
   end

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -1,12 +1,15 @@
 require 'spec_helper'
 
 describe 'zabbix::server' do
-  # Set some facts / params.
-  let(:params) { { :zabbix_version => '2.4'} }
-  let(:node) { 'rspec.puppet.com' }
+  let (:params) do
+    {
+      :zabbix_version => '2.4',
+    }
+  end
 
-  # Running an RedHat OS.
-  context 'On a RedHat OS' do
+  let (:node) { 'rspec.puppet.com' }
+
+  context 'On RedHat 6.5' do
     let :facts do
       {
         :osfamily               => 'RedHat',
@@ -22,14 +25,26 @@ describe 'zabbix::server' do
     it { should contain_service('zabbix-server').with_ensure('running') }
 
     describe 'with database_type as postgresql' do
-      let(:params) {{ :database_type => 'postgresql', :server_configfile_path => '/etc/zabbix/zabbix_server.conf', :include_dir => '/etc/zabbix/zabbix_server.conf.d' }}
+      let (:params) do
+        {
+          :database_type => 'postgresql',
+          :server_configfile_path => '/etc/zabbix/zabbix_server.conf',
+          :include_dir => '/etc/zabbix/zabbix_server.conf.d',
+        }
+      end
+
       it { should contain_package('zabbix-server-pgsql').with_ensure('present') }
       it { should contain_package('zabbix-server-pgsql').with_name('zabbix-server-pgsql') }
       it { should contain_file('/etc/zabbix/zabbix_server.conf').with_require('Package[zabbix-server-pgsql]') }
     end
 
     describe 'with database_type as mysql' do
-      let(:params) {{ :database_type => 'mysql' }}
+      let (:params) do
+        {
+          :database_type => 'mysql',
+        }
+      end
+
       it { should contain_package('zabbix-server-mysql').with_ensure('present') }
       it { should contain_package('zabbix-server-mysql').with_name('zabbix-server-mysql') }
       it { should contain_file('/etc/zabbix/zabbix_server.conf').with_require('Package[zabbix-server-mysql]') }
@@ -40,7 +55,16 @@ describe 'zabbix::server' do
     it { should contain_file('/etc/zabbix/zabbix_server.conf.d').with_require('File[/etc/zabbix/zabbix_server.conf]') }
    
     context 'with zabbix::database::postgresql class' do
-      let(:params) {{ :database_type => 'postgresql', :database_user => 'zabbix-server', :database_password => 'zabbix-server', :database_host => 'localhost', :database_name => 'zabbix-server' }}
+      let (:params) do
+        {
+          :database_type => 'postgresql',
+          :database_user => 'zabbix-server',
+          :database_password => 'zabbix-server',
+          :database_host => 'localhost',
+          :database_name => 'zabbix-server',
+        }
+      end
+
       it { should contain_class('zabbix::database::postgresql').with_zabbix_type('server')}
       it { should contain_class('zabbix::database::postgresql').with_zabbix_version('2.4')}
       it { should contain_class('zabbix::database::postgresql').with_database_name('zabbix-server')}
@@ -50,7 +74,16 @@ describe 'zabbix::server' do
     end
 
     context 'with zabbix::database::mysql class' do
-      let(:params) {{ :database_type => 'mysql', :database_user => 'zabbix-server', :database_password => 'zabbix-server', :database_host => 'localhost', :database_name => 'zabbix-server' }}
+      let (:params) do
+        {
+          :database_type => 'mysql',
+          :database_user => 'zabbix-server',
+          :database_password => 'zabbix-server',
+          :database_host => 'localhost',
+          :database_name => 'zabbix-server',
+        }
+      end
+
       it { should contain_class('zabbix::database::mysql').with_zabbix_type('server')}
       it { should contain_class('zabbix::database::mysql').with_zabbix_version('2.4')}
       it { should contain_class('zabbix::database::mysql').with_database_name('zabbix-server')}
@@ -62,333 +95,173 @@ describe 'zabbix::server' do
     # So if manage_firewall is set to true, it should install
     # the firewall rule.
     context "when declaring manage_firewall is true" do
-      let(:params) {{ :manage_firewall => true }}
+      let (:params) do
+        {
+          :manage_firewall => true,
+        }
+      end
+
       it { should contain_firewall('151 zabbix-server') }
     end
   
     context "when declaring manage_firewall is false" do
-      let(:params) {{ :manage_firewall => false }}
+      let (:params) do
+        {
+          :manage_firewall => false,
+        }
+      end
+
       it { should_not contain_firewall('151 zabbix-server') }
     end 
 
-    context 'with nodeid => 0' do
-      let(:params) { { :nodeid => '0', :zabbix_version => '2.2'} }
-      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^NodeID=0$}}
-    end
+    context "with all zabbix_server.conf-related parameters" do
+      let (:params) do
+        {
+          :alertscriptspath => '${datadir}/zabbix/alertscripts' ,
+          :allowroot => '1' ,
+          :cachesize => '8M' ,
+          :cacheupdatefrequency => '30' ,
+          :database_host => 'localhost',
+          :database_name => 'zabbix-server',
+          :database_password => 'zabbix-server',
+          :database_port => '3306',
+          :database_schema => 'zabbix-server',
+          :database_socket => '/tmp/socket.db',
+          :database_user => 'zabbix-server',
+          :debuglevel => '3',
+          :externalscripts => '/usr/lib/zabbix/externalscripts0' ,
+          :fping6location => '/usr/sbin/fping6' ,
+          :fpinglocation => '/usr/sbin/fping' ,
+          :historycachesize => '4M' ,
+          :historytextcachesize => '4M' ,
+          :housekeepingfrequency => '1' ,
+          :include_dir => '/etc/zabbix/zabbix_server.conf.d' ,
+          :javagateway => '192.168.2.2',
+          :javagateway => '192.168.2.2',
+          :javagatewayport => '10052',
+          :listenip => '192.168.1.1' ,
+          :listenport => '10051',
+          :loadmodulepath => '${libdir}/modules' ,
+          :loadmodule => 'pizza' ,
+          :logfilesize => '10',
+          :logfile => '/var/log/zabbix/zabbix_server.log',
+          :logslowqueries => '0' ,
+          :maxhousekeeperdelete => '500' ,
+          :nodeid => '0',
+          :nodeid => '0',
+          :nodenoevents => '0',
+          :nodenoevents => '0',
+          :nodenohistory => '0',
+          :nodenohistory => '0',:zabbix_version => '2.2' ,
+          :pidfile => '/var/run/zabbix/zabbix_server.pid',
+          :proxyconfigfrequency => '3600' ,
+          :proxydatafrequency => '1' ,
+          :senderfrequency => '30' ,
+          :snmptrapperfile => '/tmp/zabbix_traps.tmp',
+          :sourceip => '192.168.1.1',
+          :sshkeylocation => '/home/zabbix' ,
+          :startdbsyncers => '4' ,
+          :startdiscoverers => '1',
+          :starthttppollers => '1',
+          :startipmipollers => '12',
+          :startpingers => '1',
+          :startpollers => '12',
+          :startpollersunreachable => '1',
+          :startproxypollers => '1' ,
+          :startsnmptrapper => '1' ,
+          :starttimers => '1',
+          :starttrappers => '5',
+          :startvmwarecollectors => '5',
+          :timeout => '3' ,
+          :tmpdir => '/tmp' ,
+          :trappertimeout => '30' ,
+          :trendcachesize => '4M' ,
+          :unavailabledelay => '30' ,
+          :unreachabledelay => '30' ,
+          :unreachableperiod => '30' ,
+          :valuecachesize => '4M',
+          :vmwarecachesize => '8M',
+          :vmwarefrequency => '60',
+          :zabbix_version => '2.2',
+        }
+      end
 
-    context 'with nodeid => 0' do
-      let(:params) { { :nodeid => '0', :zabbix_version => '2.4'} }
-      it { should_not contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^NodeID=0$}}
-    end
-
-    context 'with listenport => 10051' do
-      let(:params) { { :listenport => '10051'} }
-      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^ListenPort=10051$}}
-    end
-
-    context 'with sourceip => 10051' do
-      let(:params) { { :sourceip => '192.168.1.1'} }
-      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^SourceIP=192.168.1.1}}
-    end
-
-    context 'with logfile => /var/log/zabbix/zabbix_server.log' do
-      let(:params) { { :logfile => '/var/log/zabbix/zabbix_server.log'} }
-      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^LogFile=/var/log/zabbix/zabbix_server.log}}
-    end
-
-    context 'with logfilesize => 10' do
-      let(:params) { { :logfilesize => '10'} }
-      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^LogFileSize=10}}
-    end
-
-    context 'with debuglevel => 3' do
-      let(:params) { { :debuglevel => '3'} }
-      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^DebugLevel=3}}
-    end
-
-    context 'with pidfile => /var/run/zabbix/zabbix_server.pid' do
-      let(:params) { { :pidfile => '/var/run/zabbix/zabbix_server.pid'} }
-      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^PidFile=/var/run/zabbix/zabbix_server.pid}}
-    end
-
-    context 'with database_host => localhost' do
-      let(:params) { { :database_host => 'localhost'} }
+      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^AlertScriptsPath=\$\{datadir\}/zabbix/alertscripts}}
+      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^AllowRoot=1}}
+      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^CacheSize=8M}}
+      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^CacheUpdateFrequency=30}}
       it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^DBHost=localhost}}
-    end
-
-    context 'with database_name => zabbix-server' do
-      let(:params) { { :database_name => 'zabbix-server'} }
       it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^DBName=zabbix-server}}
-    end
-
-    context 'with database_schema => zabbix-server' do
-      let(:params) { { :database_schema => 'zabbix-server'} }
-      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^DBSchema=zabbix-server}}
-    end
-
-    context 'with database_user => zabbix-server' do
-      let(:params) { { :database_user => 'zabbix-server'} }
-      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^DBUser=zabbix-server}}
-    end
-
-    context 'with database_password => zabbix-server' do
-      let(:params) { { :database_password => 'zabbix-server'} }
       it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^DBPassword=zabbix-server}}
-    end
-
-    context 'with database_socket => /tmp/socket.db' do
-      let(:params) { { :database_socket => '/tmp/socket.db'} }
-      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^DBSocket=/tmp/socket.db}}
-    end
-
-    context 'with database_port => 3306' do
-      let(:params) { { :database_port => '3306'} }
       it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^DBPort=3306}}
-    end
-
-    context 'with startpollers => 12' do
-      let(:params) { { :startpollers => '12'} }
-      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^StartPollers=12}}
-    end
-
-    context 'with startipmipollers => 12' do
-      let(:params) { { :startipmipollers => '12'} }
-      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^StartIPMIPollers=12}}
-    end
-
-    context 'with startpollersunreachable => 1' do
-      let(:params) { { :startpollersunreachable => '1'} }
-      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^StartPollersUnreachable=1}}
-    end
-
-    context 'with starttrappers => 5' do
-      let(:params) { { :starttrappers => '5'} }
-      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^StartTrappers=5}}
-    end
-
-    context 'with startpingers => 1' do
-      let(:params) { { :startpingers => '1'} }
-      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^StartPingers=1}}
-    end
-
-    context 'with startdiscoverers => 1' do
-      let(:params) { { :startdiscoverers => '1'} }
-      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^StartDiscoverers=1}}
-    end
-
-    context 'with starthttppollers => 1' do
-      let(:params) { { :starthttppollers => '1'} }
-      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^StartHTTPPollers=1}}
-    end
-
-    context 'with starttimers => 1' do
-      let(:params) { { :starttimers => '1', :zabbix_version => '2.2'} }
-      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^StartTimers=1}}
-    end
-
-    context 'with javagateway => 192.168.2.2' do
-      let(:params) { { :javagateway => '192.168.2.2'} }
+      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^DBSchema=zabbix-server}}
+      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^DBSocket=/tmp/socket.db}}
+      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^DBUser=zabbix-server}}
+      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^DebugLevel=3}}
+      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^ExternalScripts=/usr/lib/zabbix/externalscripts}}
+      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^Fping6Location=/usr/sbin/fping6}}
+      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^FpingLocation=/usr/sbin/fping}}
+      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^HistoryCacheSize=4M}}
+      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^HistoryTextCacheSize=4M}}
+      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^HousekeepingFrequency=1}}
+      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^Include=/etc/zabbix/zabbix_server.conf.d}}
       it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^JavaGateway=192.168.2.2}}
-    end
-
-    context 'with javagatewayport => 10052' do
-      let(:params) { { :javagateway => '192.168.2.2', :javagatewayport => '10052'} }
       it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^JavaGatewayPort=10052}}
-    end
-
-    context 'with startvmwarecollectors => 5' do
-      let(:params) { { :startvmwarecollectors => '5', :zabbix_version => '2.2'} }
+      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^ListenIP=192.168.1.1}}
+      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^ListenPort=10051$}}
+      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^LoadModulePath=\$\{libdir\}/modules}}
+      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^LoadModule = pizza}}
+      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^LogFileSize=10}}
+      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^LogFile=/var/log/zabbix/zabbix_server.log}}
+      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^LogSlowQueries=0}}
+      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^MaxHousekeeperDelete=500}}
+      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^NodeID=0$}}
+      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^NodeNoEvents=0}}
+      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^NodeNoHistory=0}}
+      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^PidFile=/var/run/zabbix/zabbix_server.pid}}
+      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^ProxyConfigFrequency=3600}}
+      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^ProxyDataFrequency=1}}
+      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^SenderFrequency=30}}
+      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^SNMPTrapperFile=/tmp/zabbix_traps.tmp}}
+      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^SourceIP=192.168.1.1}}
+      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^SSHKeyLocation=/home/zabbix}}
+      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^StartDBSyncers=4}}
+      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^StartDiscoverers=1}}
+      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^StartHTTPPollers=1}}
+      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^StartIPMIPollers=12}}
+      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^StartPingers=1}}
+      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^StartPollers=12}}
+      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^StartPollersUnreachable=1}}
+      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^StartProxyPollers=1}}
+      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^StartSNMPTrapper=1}}
+      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^StartTimers=1}}
+      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^StartTrappers=5}}
       it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^StartVMwareCollectors=5}}
-    end
-
-    context 'with vmwarefrequency => 60' do
-      let(:params) { { :vmwarefrequency => '60', :zabbix_version => '2.2'} }
+      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^Timeout=3}}
+      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^TmpDir=/tmp}}
+      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^TrapperTimeout=30}}
+      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^TrendCacheSize=4M}}
+      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^UnavailableDelay=30}}
+      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^UnreachableDelay=30}}
+      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^UnreachablePeriod=30}}
+      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^ValueCacheSize=4M}}
+      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^VMwareCacheSize=8M}}
       it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^VMwareFrequency=60}}
     end
 
-    context 'with vmwarecachesize => 8M' do
-      let(:params) { { :vmwarecachesize => '8M', :zabbix_version => '2.2'} }
-      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^VMwareCacheSize=8M}}
-    end
+    context "with zabbix_server.conf and version 2.4" do
+      let (:params) do
+        {
+          :nodeid => '0',
+          :nodenohistory => '0',
+          :nodenoevents => '0',
+          :zabbix_version => '2.4',
+        }
+      end
 
-    context 'with snmptrapperfile => /tmp/zabbix_traps.tmp' do
-      let(:params) { { :snmptrapperfile => '/tmp/zabbix_traps.tmp'} }
-      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^SNMPTrapperFile=/tmp/zabbix_traps.tmp}}
-    end
-
-    context 'with startsnmptrapper => 1' do
-      let(:params) { { :startsnmptrapper => '1' } }
-      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^StartSNMPTrapper=1}}
-    end
-
-    context 'with listenip => 192.168.1.1' do
-      let(:params) { { :listenip => '192.168.1.1' } }
-      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^ListenIP=192.168.1.1}}
-    end
-
-    context 'with housekeepingfrequency => 1' do
-      let(:params) { { :housekeepingfrequency => '1' } }
-      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^HousekeepingFrequency=1}}
-    end
-
-    context 'with maxhousekeeperdelete => 500' do
-      let(:params) { { :maxhousekeeperdelete => '500' } }
-      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^MaxHousekeeperDelete=500}}
-    end
-
-    context 'with senderfrequency => 30' do
-      let(:params) { { :senderfrequency => '30' } }
-      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^SenderFrequency=30}}
-    end
-
-    context 'with cachesize => 8M' do
-      let(:params) { { :cachesize => '8M' } }
-      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^CacheSize=8M}}
-    end
-
-    context 'with cacheupdatefrequency => 30' do
-      let(:params) { { :cacheupdatefrequency => '30' } }
-      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^CacheUpdateFrequency=30}}
-    end
-
-    context 'with startdbsyncers => 4' do
-      let(:params) { { :startdbsyncers => '4' } }
-      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^StartDBSyncers=4}}
-    end
-
-    context 'with historycachesize => 4M' do
-      let(:params) { { :historycachesize => '4M' } }
-      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^HistoryCacheSize=4M}}
-    end
-
-    context 'with trendcachesize => 4M' do
-      let(:params) { { :trendcachesize => '4M' } }
-      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^TrendCacheSize=4M}}
-    end
-
-    context 'with historytextcachesize => 4M' do
-      let(:params) { { :historytextcachesize => '4M' } }
-      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^HistoryTextCacheSize=4M}}
-    end
-
-    context 'with valuecachesize => 4M' do
-      let(:params) { { :valuecachesize => '4M', :zabbix_version => '2.2' } }
-      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^ValueCacheSize=4M}}
-    end
-
-    context 'with nodenoevents => 0' do
-      let(:params) { { :nodenoevents => '0', :zabbix_version => '2.2' } }
-      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^NodeNoEvents=0}}
-    end
-
-    context 'with nodenoevents => 0' do
-      let(:params) { { :nodenoevents => '0', :zabbix_version => '2.4' } }
+      it { should_not contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^NodeID=0$}}
       it { should_not contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^NodeNoEvents=0}}
-    end
-
-    context 'with nodenohistory => 0' do
-      let(:params) { { :nodenohistory => '0',:zabbix_version => '2.2' } }
-      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^NodeNoHistory=0}}
-    end
-
-    context 'with nodenohistory => 0' do
-      let(:params) { { :nodenohistory => '0', :zabbix_version => '2.4' } }
       it { should_not contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^NodeNoHistory=0}}
-    end
-
-    context 'with timeout => 3' do
-      let(:params) { { :timeout => '3' } }
-      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^Timeout=3}}
-    end
-
-    context 'with trappertimeout => 30' do
-      let(:params) { { :trappertimeout => '30' } }
-      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^TrapperTimeout=30}}
-    end
-
-    context 'with unreachableperiod => 30' do
-      let(:params) { { :unreachableperiod => '30' } }
-      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^UnreachablePeriod=30}}
-    end
-
-    context 'with unavailabledelay => 30' do
-      let(:params) { { :unavailabledelay => '30' } }
-      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^UnavailableDelay=30}}
-    end
-
-    context 'with unreachabledelay => 30' do
-      let(:params) { { :unreachabledelay => '30' } }
-      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^UnreachableDelay=30}}
-    end
-
-    context 'with alertscriptspath => ${datadir}/zabbix/alertscripts' do
-      let(:params) { { :alertscriptspath => '${datadir}/zabbix/alertscripts' } }
-      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^AlertScriptsPath=\$\{datadir\}/zabbix/alertscripts}}
-    end
-
-    context 'with externalscripts => /usr/lib/zabbix/externalscripts' do
-      let(:params) { { :externalscripts => '/usr/lib/zabbix/externalscripts0' } }
-      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^ExternalScripts=/usr/lib/zabbix/externalscripts}}
-    end
-
-    context 'with fpinglocation => /usr/sbin/fping' do
-      let(:params) { { :fpinglocation => '/usr/sbin/fping' } }
-      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^FpingLocation=/usr/sbin/fping}}
-    end
-
-    context 'with fping6location => /usr/sbin/fping6' do
-      let(:params) { { :fping6location => '/usr/sbin/fping6' } }
-      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^Fping6Location=/usr/sbin/fping6}}
-    end
-
-    context 'with sshkeylocation => /home/zabbix' do
-      let(:params) { { :sshkeylocation => '/home/zabbix' } }
-      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^SSHKeyLocation=/home/zabbix}}
-    end
-
-    context 'with logslowqueries => 0' do
-      let(:params) { { :logslowqueries => '0' } }
-      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^LogSlowQueries=0}}
-    end
-
-    context 'with tmpdir => /tmp' do
-      let(:params) { { :tmpdir => '/tmp' } }
-      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^TmpDir=/tmp}}
-    end
-
-    context 'with startproxypollers => 1' do
-      let(:params) { { :startproxypollers => '1' } }
-      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^StartProxyPollers=1}}
-    end
-
-    context 'with proxyconfigfrequency => 3600' do
-      let(:params) { { :proxyconfigfrequency => '3600' } }
-      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^ProxyConfigFrequency=3600}}
-    end
-
-    context 'with proxydatafrequency => 1' do
-      let(:params) { { :proxydatafrequency => '1' } }
-      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^ProxyDataFrequency=1}}
-    end
-
-    context 'with allowroot => 1' do
-      let(:params) { { :allowroot => '1' } }
-      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^AllowRoot=1}}
-    end
-
-    context 'with include_dir => /etc/zabbix/zabbix_server.conf.d' do
-      let(:params) { { :include_dir => '/etc/zabbix/zabbix_server.conf.d' } }
-      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^Include=/etc/zabbix/zabbix_server.conf.d}}
-    end
-
-    context 'with loadmodulepath => ${libdir}/modules' do
-      let(:params) { { :loadmodulepath => '${libdir}/modules' } }
-      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^LoadModulePath=\$\{libdir\}/modules}}
-    end
-
-    context 'with loadmodule => pizza' do
-      let(:params) { { :loadmodule => 'pizza' } }
-      it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^LoadModule = pizza}}
     end
   end
 end

--- a/spec/classes/userparameter_spec.rb
+++ b/spec/classes/userparameter_spec.rb
@@ -1,8 +1,7 @@
 require 'spec_helper'
 
 describe 'zabbix::userparameter' do
-  let(:node) { 'agent.example.com' }
-  it 'should compmile with default parameter' do
-      should compile
-  end
+  let (:node) { 'agent.example.com' }
+
+  it { should compile }
 end

--- a/spec/classes/web_spec.rb
+++ b/spec/classes/web_spec.rb
@@ -1,9 +1,13 @@
 require 'spec_helper'
 
 describe 'zabbix::web' do
-  # Set some facts / params.
-  let(:node) { 'rspec.puppet.com' }
-  let(:params) {{ :zabbix_url => 'zabbix.example.com' }}
+  let (:node) { 'rspec.puppet.com' }
+
+  let (:params) do
+    {
+      :zabbix_url => 'zabbix.example.com',
+    }
+  end
 
   # Running an RedHat OS.
   context 'On a RedHat OS' do
@@ -19,13 +23,24 @@ describe 'zabbix::web' do
     end
 
     describe 'with database_type as postgresql' do
-      let(:params) {{ :database_type => 'postgresql' }}
+      let (:params) do
+        super().merge({
+          :database_type => 'postgresql',
+        })
+      end
+
       it { should contain_package('zabbix-web-pgsql').with_name('zabbix-web-pgsql') }
       it { should contain_package('zabbix-web')}
+      it { should contain_file('/etc/zabbix/web/zabbix.conf.php').with_content(/^\$DB\['TYPE'\]     = 'POSTGRESQL'/) }
     end
 
     describe 'with database_type as mysql' do
-      let(:params) {{ :database_type => 'mysql' }}
+      let (:params) do
+        super().merge({
+          :database_type => 'mysql',
+        })
+      end
+
       it { should contain_package('zabbix-web-mysql').with_name('zabbix-web-mysql') }
       it { should contain_package('zabbix-web')}
     end
@@ -33,9 +48,13 @@ describe 'zabbix::web' do
     it { should contain_file('/etc/zabbix/web/zabbix.conf.php')}
 
     describe "when manage_resources is true" do
-      let(:params) {{ :manage_resources => true }}
+      let (:params) do
+        super().merge({
+          :manage_resources => true,
+        })
+      end
+
       it { should contain_class('zabbix::resources::web') }
-        
       it { should contain_package('zabbixapi').that_requires('Class[ruby::dev]').with_provider('gem') }
       it { should contain_class('ruby::dev') }
     end
@@ -49,70 +68,56 @@ describe 'zabbix::web' do
       end
 
       let (:params) do
-        {
+        super().merge({
           :manage_resources => true
-        }
+        })
       end
 
       it { should contain_package('zabbixapi').with_provider('pe_puppetserver_gem') }
     end
     
     describe "when manage_resources is false" do
-      let(:params) {{ :manage_resources => false}}
+      let (:params) do
+        super().merge({
+          :manage_resources => false,
+        })
+      end
+
       it { should_not contain_class('zabbix::resources::web') }
     end
 
     it { should contain_apache__vhost('zabbix.example.com').with_name('zabbix.example.com') }
 
-    context 'with database_type => postgresql' do
-      let(:params) { { :database_type => 'postgresql' } }
-      it { should contain_file('/etc/zabbix/web/zabbix.conf.php').with_content(/^\$DB\['TYPE'\]     = 'POSTGRESQL'/) }
-    end
+    context 'with database_* settings' do
+      let (:params) do
+        super().merge({
+          :database_host => 'localhost',
+          :database_name => 'zabbix-server',
+          :database_user => 'zabbix-server',
+          :database_password => 'zabbix-server',
+          :zabbix_server => 'localhost',
+        })
+      end
 
-    context 'with database_host => localhost' do
-      let(:params) { { :database_host => 'localhost' } }
       it { should contain_file('/etc/zabbix/web/zabbix.conf.php').with_content(/^\$DB\['SERVER'\]   = 'localhost'/) }
-    end
-
-    context 'with database_name => zabbix-server' do
-      let(:params) { { :database_name => 'zabbix-server' } }
       it { should contain_file('/etc/zabbix/web/zabbix.conf.php').with_content(/^\$DB\['DATABASE'\] = 'zabbix-server'/) }
-    end
-
-    context 'with database_user => zabbix-server' do
-      let(:params) { { :database_user => 'zabbix-server' } }
       it { should contain_file('/etc/zabbix/web/zabbix.conf.php').with_content(/^\$DB\['USER'\]     = 'zabbix-server'/) }
-    end
-
-    context 'with database_password => zabbix-server' do
-      let(:params) { { :database_password => 'zabbix-server' } }
       it { should contain_file('/etc/zabbix/web/zabbix.conf.php').with_content(/^\$DB\['PASSWORD'\] = 'zabbix-server'/) }
-    end
-
-    context 'with zabbix_server => localhost' do
-      let(:params) { { :zabbix_server => 'localhost' } }
       it { should contain_file('/etc/zabbix/web/zabbix.conf.php').with_content(/^\$ZBX_SERVER      = 'localhost'/) }
-    end
-
-    context 'with zabbix_listenport => localhost' do
-      let(:params) { { :zabbix_listenport => '10051' } }
-      it { should contain_file('/etc/zabbix/web/zabbix.conf.php').with_content(/^\$ZBX_SERVER_PORT = '10051'/) }
-    end
-
-    context 'with zabbix_server => localhost' do
-      let(:params) { { :zabbix_server => 'localhost' } }
-      it { should contain_file('/etc/zabbix/web/zabbix.conf.php').with_content(/^\$ZBX_SERVER_NAME = 'localhost'/) }
     end
   end
 end
 
 describe 'zabbix::web' do
-  # Set some facts / params.
-  let(:node) { 'rspec.puppet.com' }
-  let(:params) {{ :zabbix_url => 'zabbix.example.com' }}
+  let (:node) { 'rspec.puppet.com' }
 
-  # Running an Debian OS.
-  context 'On a Debian OS' do
+  let (:params) do
+    {
+      :zabbix_url => 'zabbix.example.com',
+    }
+  end
+
+  context 'On Debian 6.0' do
     let :facts do
       {
         :osfamily               => 'debian',
@@ -121,9 +126,10 @@ describe 'zabbix::web' do
         :lsbdistcodename        => 'squeeze',
         :architecture           => 'x86_64',
         :lsbdistid              => 'debian',
-        :concat_basedir         => '/tmp'
+        :concat_basedir         => '/tmp',
       }
     end
-  it { should contain_package('zabbix-frontend-php')}
+
+    it { should contain_package('zabbix-frontend-php') }
   end
 end

--- a/templates/zabbix_server.conf.erb
+++ b/templates/zabbix_server.conf.erb
@@ -395,5 +395,5 @@ LoadModulePath=<%= @loadmodulepath %>
 #	it is allowed to include multiple loadmodule parameters.
 #
 <% if @loadmodule %>
-LoadModule = <%= loadmodule %>
+LoadModule = <%= @loadmodule %>
 <% end %>


### PR DESCRIPTION
This is an update to the Travis CI configuration and a rewrite of all rspec tests that standardizes them using the same layout. It also includes the fixes to the code required to get the rspec tests to pass with Puppet 3 and 4.

It does remove Puppet 2.7 from the test matrix. 2.7 is no longer supported and rspec generates a ton of failures that cannot be fixed without massive rewrites to the code. I believe this is fine, but it is up to you to accept it or not.

Fixes #160 