### PR TITLE
Adjust server config and databases sqls for 3.0

### DIFF
--- a/manifests/database/mysql.pp
+++ b/manifests/database/mysql.pp
@@ -25,11 +25,20 @@ class zabbix::database::mysql (
   $database_host        = '',
   $database_path        = $zabbix::params::database_path,
 ) {
+  # Adjustments for version 3.0 - structure of package with sqls differs from previous versions
+  case $zabbix_version {
+    '3.0': {
+      $sql_dir = ''
+    }
+    default: {
+      $sql_dir = 'create'
+    }
+  }
   # Allow to customize the path to the Database Schema,
   if ($database_schema_path == false) or ($database_schema_path == '') {
     case $::operatingsystem {
       'CentOS','RedHat','OracleLinux' : {
-        $schema_path = "/usr/share/doc/zabbix-*-mysql-${zabbix_version}*/"
+        $schema_path = "/usr/share/doc/zabbix-*-mysql-${zabbix_version}*/${sql_dir}"
       }
       default : {
         $schema_path = '/usr/share/zabbix-*-mysql'
@@ -38,10 +47,6 @@ class zabbix::database::mysql (
   }
   else {
     $schema_path = $database_schema_path
-  }
-
-  if ($zabbix_version != '3.0') {
-    $schema_path   = "${schema_path}/create"
   }
 
   # Loading the sql files.

--- a/manifests/database/mysql.pp
+++ b/manifests/database/mysql.pp
@@ -48,12 +48,12 @@ class zabbix::database::mysql (
   case $zabbix_type {
     'proxy': {
       case $zabbix_version {
-            '3.0': {
-                  $zabbix_proxy_create_sql = "cd ${schema_path} && if [ -f create.sql.gz ]; then gunzip create.sql.gz ; fi && mysql -h '${database_host}' -u '${database_user}' -p'${database_password}' -D '${database_name}' < create.sql && touch /etc/zabbix/.schema.done"
-             }
-             default: {
-                  $zabbix_proxy_create_sql = "cd ${schema_path} && if [ -f schema.sql.gz ]; then gunzip schema.sql.gz ; fi && mysql -h '${database_host}' -u '${database_user}' -p'${database_password}' -D '${database_name}' < schema.sql && touch /etc/zabbix/.schema.done"
-             }
+        '3.0': {
+          $zabbix_proxy_create_sql = "cd ${schema_path} && if [ -f create.sql.gz ]; then gunzip create.sql.gz ; fi && mysql -h '${database_host}' -u '${database_user}' -p'${database_password}' -D '${database_name}' < create.sql && touch /etc/zabbix/.schema.done"
+        }
+        default: {
+          $zabbix_proxy_create_sql = "cd ${schema_path} && if [ -f schema.sql.gz ]; then gunzip schema.sql.gz ; fi && mysql -h '${database_host}' -u '${database_user}' -p'${database_password}' -D '${database_name}' < schema.sql && touch /etc/zabbix/.schema.done"
+        }
       }
 
       exec { 'zabbix_proxy_create.sql':
@@ -67,16 +67,16 @@ class zabbix::database::mysql (
     }
     'server': {
       case $zabbix_version {
-          '3.0': {
-             $zabbix_server_create_sql = "cd ${schema_path} && if [ -f create.sql.gz ]; then gunzip create.sql.gz ; fi && mysql -h '${database_host}' -u '${database_user}' -p'${database_password}' -D '${database_name}' < create.sql && touch /etc/zabbix/.schema.done"
-             $zabbix_server_images_sql = "touch /etc/zabbix/.images.done"
-             $zabbix_server_data_sql   = "touch /etc/zabbix/.data.done"
-           }
-           default: {
-             $zabbix_server_create_sql = "cd ${schema_path} && if [ -f schema.sql.gz ]; then gunzip schema.sql.gz ; fi && mysql -h '${database_host}' -u '${database_user}' -p'${database_password}' -D '${database_name}' < schema.sql && touch /etc/zabbix/.schema.done"
-             $zabbix_server_images_sql = "cd ${schema_path} && if [ -f images.sql.gz ]; then gunzip images.sql.gz ; fi && mysql -h '${database_host}' -u '${database_user}' -p'${database_password}' -D '${database_name}' < images.sql && touch /etc/zabbix/.images.done"
-             $zabbix_server_data_sql   = "cd ${schema_path} && if [ -f data.sql.gz ]; then gunzip data.sql.gz ; fi && mysql -h '${database_host}' -u '${database_user}' -p'${database_password}' -D '${database_name}' < data.sql && touch /etc/zabbix/.data.done"
-           }
+        '3.0': {
+          $zabbix_server_create_sql = "cd ${schema_path} && if [ -f create.sql.gz ]; then gunzip create.sql.gz ; fi && mysql -h '${database_host}' -u '${database_user}' -p'${database_password}' -D '${database_name}' < create.sql && touch /etc/zabbix/.schema.done"
+          $zabbix_server_images_sql = 'touch /etc/zabbix/.images.done'
+          $zabbix_server_data_sql   = 'touch /etc/zabbix/.data.done'
+        }
+        default: {
+          $zabbix_server_create_sql = "cd ${schema_path} && if [ -f schema.sql.gz ]; then gunzip schema.sql.gz ; fi && mysql -h '${database_host}' -u '${database_user}' -p'${database_password}' -D '${database_name}' < schema.sql && touch /etc/zabbix/.schema.done"
+          $zabbix_server_images_sql = "cd ${schema_path} && if [ -f images.sql.gz ]; then gunzip images.sql.gz ; fi && mysql -h '${database_host}' -u '${database_user}' -p'${database_password}' -D '${database_name}' < images.sql && touch /etc/zabbix/.images.done"
+          $zabbix_server_data_sql   = "cd ${schema_path} && if [ -f data.sql.gz ]; then gunzip data.sql.gz ; fi && mysql -h '${database_host}' -u '${database_user}' -p'${database_password}' -D '${database_name}' < data.sql && touch /etc/zabbix/.data.done"
+        }
       }
       exec { 'zabbix_server_create.sql':
         command  => $zabbix_server_create_sql,

--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -63,13 +63,13 @@ class zabbix::database::postgresql (
 
   case $zabbix_type {
       'proxy': {
-	case $zabbix_version {
-          '3.0': { 
-             $zabbix_proxy_create_sql = "cd ${schema_path} && if [ -f create.sql.gz ]; then gunzip create.sql.gz ; fi && psql -h '${database_host}' -U '${database_user}' -d '${database_name}' -f create.sql && touch /etc/zabbix/.schema.done"
-	   }
-           default: {
-             $zabbix_proxy_create_sql = "cd ${schema_path} && if [ -f schema.sql.gz ]; then gunzip schema.sql.gz ; fi && psql -h '${database_host}' -U '${database_user}' -d '${database_name}' -f schema.sql && touch /etc/zabbix/.schema.done"
-           }
+        case $zabbix_version {
+          '3.0': {
+            $zabbix_proxy_create_sql = "cd ${schema_path} && if [ -f create.sql.gz ]; then gunzip create.sql.gz ; fi && psql -h '${database_host}' -U '${database_user}' -d '${database_name}' -f create.sql && touch /etc/zabbix/.schema.done"
+          }
+          default: {
+            $zabbix_proxy_create_sql = "cd ${schema_path} && if [ -f schema.sql.gz ]; then gunzip schema.sql.gz ; fi && psql -h '${database_host}' -U '${database_user}' -d '${database_name}' -f schema.sql && touch /etc/zabbix/.schema.done"
+          }
         }
 
         exec { 'zabbix_proxy_create.sql':
@@ -83,17 +83,17 @@ class zabbix::database::postgresql (
         }
       }
       'server': {
-	case $zabbix_version {
-          '3.0': { 
-             $zabbix_server_create_sql = "cd ${schema_path} && if [ -f create.sql.gz ]; then gunzip create.sql.gz ; fi && psql -h '${database_host}' -U '${database_user}' -d '${database_name}' -f create.sql && touch /etc/zabbix/.schema.done"
-             $zabbix_server_images_sql = "touch /etc/zabbix/.images.done"
-             $zabbix_server_data_sql   = "touch /etc/zabbix/.data.done"
-	   }
-           default: {
-             $zabbix_server_create_sql = "cd ${schema_path} && if [ -f schema.sql.gz ]; then gunzip schema.sql.gz ; fi && psql -h '${database_host}' -U '${database_user}' -d '${database_name}' -f schema.sql && touch /etc/zabbix/.schema.done"
-             $zabbix_server_images_sql = "cd ${schema_path} && if [ -f images.sql.gz ]; then gunzip images.sql.gz ; fi && psql -h '${database_host}' -U '${database_user}' -d '${database_name}' -f images.sql && touch /etc/zabbix/.images.done"
-             $zabbix_server_data_sql   = "cd ${schema_path} && if [ -f data.sql.gz ]; then gunzip data.sql.gz ; fi && psql -h '${database_host}' -U '${database_user}' -d '${database_name}' -f data.sql && touch /etc/zabbix/.data.done"
-           }
+        case $zabbix_version {
+          '3.0': {
+            $zabbix_server_create_sql = "cd ${schema_path} && if [ -f create.sql.gz ]; then gunzip create.sql.gz ; fi && psql -h '${database_host}' -U '${database_user}' -d '${database_name}' -f create.sql && touch /etc/zabbix/.schema.done"
+            $zabbix_server_images_sql = 'touch /etc/zabbix/.images.done'
+            $zabbix_server_data_sql   = 'touch /etc/zabbix/.data.done'
+          }
+          default: {
+            $zabbix_server_create_sql = "cd ${schema_path} && if [ -f schema.sql.gz ]; then gunzip schema.sql.gz ; fi && psql -h '${database_host}' -U '${database_user}' -d '${database_name}' -f schema.sql && touch /etc/zabbix/.schema.done"
+            $zabbix_server_images_sql = "cd ${schema_path} && if [ -f images.sql.gz ]; then gunzip images.sql.gz ; fi && psql -h '${database_host}' -U '${database_user}' -d '${database_name}' -f images.sql && touch /etc/zabbix/.images.done"
+            $zabbix_server_data_sql   = "cd ${schema_path} && if [ -f data.sql.gz ]; then gunzip data.sql.gz ; fi && psql -h '${database_host}' -U '${database_user}' -d '${database_name}' -f data.sql && touch /etc/zabbix/.data.done"
+          }
         }
         exec { 'zabbix_server_create.sql':
           command  => $zabbix_server_create_sql,

--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -29,7 +29,7 @@ class zabbix::database::postgresql (
   if ($database_schema_path == false) or ($database_schema_path == '') {
     case $::operatingsystem {
       'CentOS', 'RedHat', 'OracleLinux': {
-        $schema_path   = "/usr/share/doc/zabbix-*-pgsql-${zabbix_version}*/create"
+        $schema_path   = "/usr/share/doc/zabbix-*-pgsql-${zabbix_version}*/"
       }
       default : {
         $schema_path   = '/usr/share/zabbix-*-pgsql'
@@ -39,6 +39,11 @@ class zabbix::database::postgresql (
   else {
     $schema_path = $database_schema_path
   }
+
+  if ($zabbix_version != '3.0') {
+    $schema_path   = "${schema_path}/create"
+  }
+
 
 
   exec { 'update_pgpass':
@@ -57,46 +62,67 @@ class zabbix::database::postgresql (
   }
 
   case $zabbix_type {
-    'proxy': {
-      exec { 'zabbix_proxy_create.sql':
-        command  => "cd ${schema_path} && if [ -f schema.sql.gz ]; then gunzip schema.sql.gz ; fi && psql -h '${database_host}' -U '${database_user}' -d '${database_name}' -f schema.sql && touch /etc/zabbix/.schema.done",
-        path     => "/bin:/usr/bin:/usr/local/sbin:/usr/local/bin:${database_path}",
-        unless   => 'test -f /etc/zabbix/.schema.done',
-        provider => 'shell',
-        require  => [
-          Exec['update_pgpass'],
-        ],
+      'proxy': {
+	case $zabbix_version {
+          '3.0': { 
+             $zabbix_proxy_create_sql = "cd ${schema_path} && if [ -f create.sql.gz ]; then gunzip create.sql.gz ; fi && psql -h '${database_host}' -U '${database_user}' -d '${database_name}' -f create.sql && touch /etc/zabbix/.schema.done"
+	   }
+           default: {
+             $zabbix_proxy_create_sql = "cd ${schema_path} && if [ -f schema.sql.gz ]; then gunzip schema.sql.gz ; fi && psql -h '${database_host}' -U '${database_user}' -d '${database_name}' -f schema.sql && touch /etc/zabbix/.schema.done"
+           }
+        }
+
+        exec { 'zabbix_proxy_create.sql':
+          command  => $zabbix_proxy_create_sql,
+          path     => "/bin:/usr/bin:/usr/local/sbin:/usr/local/bin:${database_path}",
+          unless   => 'test -f /etc/zabbix/.schema.done',
+          provider => 'shell',
+          require  => [
+            Exec['update_pgpass'],
+          ],
+        }
       }
-    }
-    'server': {
-      exec { 'zabbix_server_create.sql':
-        command  => "cd ${schema_path} && if [ -f schema.sql.gz ]; then gunzip schema.sql.gz ; fi && psql -h '${database_host}' -U '${database_user}' -d '${database_name}' -f schema.sql && touch /etc/zabbix/.schema.done",
-        path     => "/bin:/usr/bin:/usr/local/sbin:/usr/local/bin:${database_path}",
-        unless   => 'test -f /etc/zabbix/.schema.done',
-        provider => 'shell',
-        require  => [
-          Exec['update_pgpass'],
-        ],
-      } ->
-      exec { 'zabbix_server_images.sql':
-        command  => "cd ${schema_path} && if [ -f images.sql.gz ]; then gunzip images.sql.gz ; fi && psql -h '${database_host}' -U '${database_user}' -d '${database_name}' -f images.sql && touch /etc/zabbix/.images.done",
-        path     => "/bin:/usr/bin:/usr/local/sbin:/usr/local/bin:${database_path}",
-        unless   => 'test -f /etc/zabbix/.images.done',
-        provider => 'shell',
-        require  => [
-          Exec['update_pgpass'],
-        ],
-      } ->
-      exec { 'zabbix_server_data.sql':
-        command  => "cd ${schema_path} && if [ -f data.sql.gz ]; then gunzip data.sql.gz ; fi && psql -h '${database_host}' -U '${database_user}' -d '${database_name}' -f data.sql && touch /etc/zabbix/.data.done",
-        path     => "/bin:/usr/bin:/usr/local/sbin:/usr/local/bin:${database_path}",
-        unless   => 'test -f /etc/zabbix/.data.done',
-        provider => 'shell',
-        require  => [
-          Exec['update_pgpass'],
-        ],
+      'server': {
+	case $zabbix_version {
+          '3.0': { 
+             $zabbix_server_create_sql = "cd ${schema_path} && if [ -f create.sql.gz ]; then gunzip create.sql.gz ; fi && psql -h '${database_host}' -U '${database_user}' -d '${database_name}' -f create.sql && touch /etc/zabbix/.schema.done"
+             $zabbix_server_images_sql = "touch /etc/zabbix/.images.done"
+             $zabbix_server_data_sql   = "touch /etc/zabbix/.data.done"
+	   }
+           default: {
+             $zabbix_server_create_sql = "cd ${schema_path} && if [ -f schema.sql.gz ]; then gunzip schema.sql.gz ; fi && psql -h '${database_host}' -U '${database_user}' -d '${database_name}' -f schema.sql && touch /etc/zabbix/.schema.done"
+             $zabbix_server_images_sql = "cd ${schema_path} && if [ -f images.sql.gz ]; then gunzip images.sql.gz ; fi && psql -h '${database_host}' -U '${database_user}' -d '${database_name}' -f images.sql && touch /etc/zabbix/.images.done"
+             $zabbix_server_data_sql   = "cd ${schema_path} && if [ -f data.sql.gz ]; then gunzip data.sql.gz ; fi && psql -h '${database_host}' -U '${database_user}' -d '${database_name}' -f data.sql && touch /etc/zabbix/.data.done"
+           }
+        }
+        exec { 'zabbix_server_create.sql':
+          command  => $zabbix_server_create_sql,
+          path     => "/bin:/usr/bin:/usr/local/sbin:/usr/local/bin:${database_path}",
+          unless   => 'test -f /etc/zabbix/.schema.done',
+          provider => 'shell',
+          require  => [
+            Exec['update_pgpass'],
+          ],
+        } ->
+        exec { 'zabbix_server_images.sql':
+          command  => $zabbix_server_images_sql,
+          path     => "/bin:/usr/bin:/usr/local/sbin:/usr/local/bin:${database_path}",
+          unless   => 'test -f /etc/zabbix/.images.done',
+          provider => 'shell',
+          require  => [
+            Exec['update_pgpass'],
+          ],
+        } ->
+        exec { 'zabbix_server_data.sql':
+          command  => $zabbix_server_data_sql,
+          path     => "/bin:/usr/bin:/usr/local/sbin:/usr/local/bin:${database_path}",
+          unless   => 'test -f /etc/zabbix/.data.done',
+          provider => 'shell',
+          require  => [
+            Exec['update_pgpass'],
+          ],
+        }
       }
-    }
     default: {
       fail 'We do not work.'
     }

--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -25,11 +25,20 @@ class zabbix::database::postgresql (
   $database_host        = '',
   $database_path        = $zabbix::params::database_path,
 ) {
+  # Adjustments for version 3.0 - structure of package with sqls differs from previous versions
+  case $zabbix_version {
+    '3.0': {
+      $sql_dir = ''
+    }
+    default: {
+      $sql_dir = 'create'
+    }
+  }
   # Allow to customize the path to the Database Schema,
   if ($database_schema_path == false) or ($database_schema_path == '') {
     case $::operatingsystem {
       'CentOS', 'RedHat', 'OracleLinux': {
-        $schema_path   = "/usr/share/doc/zabbix-*-pgsql-${zabbix_version}*/"
+        $schema_path   = "/usr/share/doc/zabbix-*-pgsql-${zabbix_version}*/${sql_dir}"
       }
       default : {
         $schema_path   = '/usr/share/zabbix-*-pgsql'
@@ -39,12 +48,6 @@ class zabbix::database::postgresql (
   else {
     $schema_path = $database_schema_path
   }
-
-  if ($zabbix_version != '3.0') {
-    $schema_path   = "${schema_path}/create"
-  }
-
-
 
   exec { 'update_pgpass':
     command => "echo ${database_host}:5432:${database_name}:${database_user}:${database_password} >> /root/.pgpass",

--- a/templates/zabbix_server.conf.erb
+++ b/templates/zabbix_server.conf.erb
@@ -3,7 +3,7 @@
 # visit http://www.zabbix.com
 
 ############ general parameters #################
-<% if @zabbix_version != '2.4' %>
+<% if @zabbix_version != '2.4' and @zabbix_version != '3.0' %>
 ### option: nodeid
 #	unique nodeid in distributed setup.
 #	0 - standalone server
@@ -236,11 +236,13 @@ HistoryCacheSize=<%= @historycachesize %>
 #
 TrendCacheSize=<%= @trendcachesize %>
 
+<% if @zabbix_version != '3.0' %>
 ### option: historytextcachesize
 #	size of text history cache, in bytes.
 #	shared memory size for storing character, text or log history data.
 #
 HistoryTextCacheSize=<%= @historytextcachesize %>
+<% end %>
 
 <% if @zabbix_version == '2.2'  or @zabbix_version == '2.4' %>
 ### option: valuecachesize
@@ -251,7 +253,7 @@ HistoryTextCacheSize=<%= @historytextcachesize %>
 ValueCacheSize=<%= @valuecachesize %>
 <% end %>
 
-<% if @zabbix_version != '2.4' %>
+<% if @zabbix_version != '2.4' and @zabbix_version != '3.0' %>
 ### option: nodenoevents
 #	if set to '1' local events won't be sent to master node.
 #	this won't impact ability of this node to propagate events from its child nodes.


### PR DESCRIPTION
I've prepared a fix for version 3.0. It looks like guys from Zabbix have changed package structure with sqls - now there's only a single file in an upper directory.
I also needed to adjust server config template. Maybe it's not the most elegant solution, but it works.