### PR TITLE
LoadModulePath for Zabbix 3.0

### DIFF
--- a/templates/zabbix_agentd.conf.erb
+++ b/templates/zabbix_agentd.conf.erb
@@ -215,7 +215,7 @@ UnsafeUserParameters=<%= @unsafeuserparameters %>
 # disabled. an configuration file should be placed on directory: <%= @include %>
 
 ####### LOADABLE MODULES #######
-<% if @zabbix_version == '2.2' or @zabbix_version == '2.4' %>
+<% if @zabbix_version == '2.2' or @zabbix_version == '2.4' or @zabbix_version == '3.0' %>
 ### Option: LoadModulePath
 #       Full path to location of agent modules.
 #       Default depends on compilation options.


### PR DESCRIPTION
LoadModulePath is still there. https://www.zabbix.com/documentation/3.0/manual/appendix/config/zabbix_agentd