### PR TITLE
Make types runnable in puppet 4

### DIFF
--- a/lib/puppet/type/zabbix_application.rb
+++ b/lib/puppet/type/zabbix_application.rb
@@ -1,3 +1,4 @@
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__),"..",".."))
 require 'puppet/util/zabbix'
 
 Puppet::Type.newtype(:zabbix_application) do
@@ -34,4 +35,3 @@ Puppet::Type.newtype(:zabbix_application) do
 
   Puppet::Util::Zabbix.add_zabbix_type_methods(self)
 end
-

--- a/lib/puppet/type/zabbix_hostgroup.rb
+++ b/lib/puppet/type/zabbix_hostgroup.rb
@@ -1,3 +1,4 @@
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__),"..",".."))
 require 'puppet/util/zabbix'
 
 Puppet::Type.newtype(:zabbix_hostgroup) do

--- a/lib/puppet/type/zabbix_template_host.rb
+++ b/lib/puppet/type/zabbix_template_host.rb
@@ -1,3 +1,4 @@
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__),"..",".."))
 require 'puppet/util/zabbix'
 
 Puppet::Type.newtype(:zabbix_template_host) do

--- a/lib/puppet/type/zabbix_userparameters.rb
+++ b/lib/puppet/type/zabbix_userparameters.rb
@@ -1,3 +1,4 @@
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__),"..",".."))
 Puppet::Type.newtype(:zabbix_userparameters) do
   ensurable do
     defaultvalues


### PR DESCRIPTION
These little changes allow puppet to find required files.

However my ruby skills are limited and I currently can't estimate, if `puppet/provider/*` also needs updates.