### PR TITLE
updated to include Amazon Linux

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -35,6 +35,10 @@ class zabbix::repo (
         $majorrelease = '6'
         $reponame     = $majorrelease
       }
+      'Amazon'        : {
+        $majorrelease = '6'
+        $reponame     = $majorrelease
+      }
       'oraclelinux' : {
         $majorrelease = $::operatingsystemmajrelease
         $reponame     = $majorrelease


### PR DESCRIPTION
will run on EL 6 library as EL 7 isn't supported by Amazon Linux and Amazon Linux doesn't have systemd