### PR TITLE
Feature selinux

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -509,8 +509,8 @@ class zabbix::server (
   # check if selinux is active and allow zabbix
   if $::selinux_config_mode == 'enforcing' {
     selboolean{'zabbix_can_network':
-      persistent  => true,
-      value       => 'on',
+      persistent => true,
+      value      => 'on',
     }
   }
 }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -505,4 +505,12 @@ class zabbix::server (
         'ESTABLISHED'],
     }
   }
+
+  # check if selinux is active and allow zabbix
+  if $::selinux_config_mode == 'enforcing' {
+    selboolean{'zabbix_can_network':
+      persistent  => true,
+      value       => 'on',
+    }
+  }
 }

--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -424,4 +424,12 @@ class zabbix::web (
       require         => Package[$zabbix_web_package],
     }
   } # END if $manage_vhost
+
+  # check if selinux is active and allow zabbix
+  if $::selinux_config_mode == 'enforcing' {
+    selboolean{'httpd_can_connect_zabbix':
+      persistent => true,
+      value      => 'on',
+    }
+  }
 }

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -34,8 +34,18 @@ describe 'zabbix::server' do
       }
     end
 
-    it { should contain_class('zabbix::repo') }
-    it { should contain_service('zabbix-server').with_ensure('running') }
+    describe 'with default settings' do
+      it { should contain_class('zabbix::repo') }
+      it { should contain_service('zabbix-server').with_ensure('running') }
+      it { should_not contain_selboolean('zabbix_can_network') }
+    end
+
+    describe 'with enabled selinux' do
+      let :facts do
+        super().merge(selinux_config_mode: 'enforcing')
+      end
+      it { should contain_selboolean('zabbix_can_network').with('value' => 'on', 'persistent' => true) }
+    end
 
     describe 'with database_type as postgresql' do
       let :params do

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -29,7 +29,8 @@ describe 'zabbix::server' do
         lsbdistcodename: '',
         id: 'root',
         kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin:/sbin'
+        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin:/sbin',
+        selinux_config_mode: ''
       }
     end
 

--- a/spec/classes/web_spec.rb
+++ b/spec/classes/web_spec.rb
@@ -34,7 +34,8 @@ describe 'zabbix::web' do
         lsbdistcodename: '',
         id: 'root',
         kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin:/sbin'
+        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin:/sbin',
+        selinux_config_mode: ''
       }
     end
 
@@ -148,7 +149,8 @@ describe 'zabbix::web' do
         lsbdistcodename: 'squeeze',
         id: 'root',
         kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin:/sbin'
+        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin:/sbin',
+        selinux_config_mode: ''
       }
     end
 

--- a/spec/classes/web_spec.rb
+++ b/spec/classes/web_spec.rb
@@ -41,6 +41,14 @@ describe 'zabbix::web' do
 
     describe 'with default settings' do
       it { should contain_file('/etc/zabbix/web').with_ensure('directory') }
+      it { should_not contain_selboolean('httpd_can_connect_zabbix') }
+    end
+
+    describe 'with enabled selinux' do
+      let :facts do
+        super().merge(selinux_config_mode: 'enforcing')
+      end
+      it { should contain_selboolean('httpd_can_connect_zabbix').with('value' => 'on', 'persistent' => true) }
     end
 
     describe 'with database_type as postgresql' do


### PR DESCRIPTION
two additions to make zabbix + selinux working. you maybe also need:

```puppet
Selboolean{
  persistent  => true,
  value       => 'on',
}
selboolean{'httpd_can_network_connect_db': }
selboolean { 'httpd_can_network_connect': }
```

but this is really apache specific and should be handled by the apache module or by a profile. This PR is related to https://github.com/dj-wasabi/puppet-zabbix/issues/190