### PR TITLE
add Arch Linux to metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -33,6 +33,7 @@
     { "operatingsystem":"Ubuntu", "operatingsystemrelease": [ "12.04", "14.04" ] },
     { "operatingsystem":"Debian", "operatingsystemrelease": [ "6.0", "7.0", "8.0" ]  },
     { "operatingsystem":"PSBM", "operatingsystemrelease": [ "5.0" ]  },
-    { "operatingsystem":"PCS", "operatingsystemrelease": [ "6.0" ]  }
+    { "operatingsystem":"PCS", "operatingsystemrelease": [ "6.0" ]  },
+    { "operatingsystem":"Archlinux" }
    ]
 }


### PR DESCRIPTION
Arch is a rolling release distribution, the operatingsystemrelease fact
only returns the current booted kernel. Relying on that isn't useful
here.